### PR TITLE
Redis, Security, Jwt 관련 설정 및 예외 처리, AWS 배포 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ group = 'wegrus'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+jar {
+	enabled = false
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/src/main/java/wegrus/clubwebsite/advice/GlobalExceptionHandler.java
+++ b/src/main/java/wegrus/clubwebsite/advice/GlobalExceptionHandler.java
@@ -1,0 +1,72 @@
+package wegrus.clubwebsite.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+import wegrus.clubwebsite.exception.BusinessException;
+
+import javax.validation.ConstraintViolationException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static wegrus.clubwebsite.dto.error.ErrorCode.*;
+
+@RestControllerAdvice("wegrus.clubwebsite.controller")
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode, e.getErrors());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package wegrus.clubwebsite.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try (OutputStream os = response.getOutputStream()){
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, ErrorResponse.of(errorCode));
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package wegrus.clubwebsite.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try (OutputStream os = response.getOutputStream()){
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, ErrorResponse.of(errorCode));
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
@@ -11,7 +11,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import wegrus.clubwebsite.exception.AuthorizationHeaderInvalidException;
-import wegrus.clubwebsite.service.JwtUserDetailsService;
+import wegrus.clubwebsite.util.JwtUserDetailsUtil;
 import wegrus.clubwebsite.util.JwtTokenUtil;
 
 import javax.servlet.FilterChain;
@@ -26,7 +26,7 @@ import static wegrus.clubwebsite.dto.error.ErrorCode.*;
 @RequiredArgsConstructor
 public class JwtRequestFilter extends OncePerRequestFilter {
 
-    private final JwtUserDetailsService jwtUserDetailsService;
+    private final JwtUserDetailsUtil jwtUserDetailsUtil;
     private final JwtTokenUtil jwtTokenUtil;
 
     @Override
@@ -40,7 +40,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             String id = jwtTokenUtil.getUsernameFromAccessToken(jwtToken);
 
             if (id != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(id);
+                UserDetails userDetails = this.jwtUserDetailsUtil.loadUserByUsername(id);
 
                 if (jwtTokenUtil.validateAccessToken(jwtToken)) {
                     UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
@@ -1,0 +1,63 @@
+package wegrus.clubwebsite.config;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import wegrus.clubwebsite.exception.AuthorizationHeaderInvalidException;
+import wegrus.clubwebsite.service.JwtUserDetailsService;
+import wegrus.clubwebsite.util.JwtTokenUtil;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static wegrus.clubwebsite.dto.error.ErrorCode.*;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private final JwtUserDetailsService jwtUserDetailsService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestTokenHeader = request.getHeader("Authorization");
+
+        try {
+            if (requestTokenHeader == null || !requestTokenHeader.startsWith("Bearer "))
+                throw new AuthorizationHeaderInvalidException();
+            String jwtToken = requestTokenHeader.substring(7);
+            String id = jwtTokenUtil.getUsernameFromAccessToken(jwtToken);
+
+            if (id != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(id);
+
+                if (jwtTokenUtil.validateAccessToken(jwtToken)) {
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        } catch (AuthorizationHeaderInvalidException e) {
+            request.setAttribute("errorCode", INVALID_AUTHORIZATION_HEADER);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("errorCode", EXPIRED_ACCESS_TOKEN);
+        } catch (JwtException e) {
+            request.setAttribute("errorCode", INVALID_JWT);
+        } catch (AccessDeniedException e) {
+            request.setAttribute("errorCode", INSUFFICIENT_AUTHORITY);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/config/RedisConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package wegrus.clubwebsite.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.url}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(){
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
@@ -1,0 +1,100 @@
+package wegrus.clubwebsite.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+import static org.springframework.web.cors.CorsConfiguration.ALL;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final UserDetailsService userDetailsService;
+    private final JwtRequestFilter jwtRequestFilter;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+    }
+
+    @Bean
+    @Override
+    protected AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/static/css/**, /static/js/**, *.ico");
+
+        // swagger
+        web.ignoring().antMatchers(
+                "/v2/api-docs", "/configuration/ui", "/swagger-resources",
+                "/configuration/security", "/swagger-ui.html", "/webjars/**", "/swagger/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .cors().configurationSource(corsConfigurationSource())
+                .and()
+
+                .authorizeRequests()
+                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                .antMatchers("/", "/swagger-resources/**", "/swagger-ui/**", "/signup/**", "/login").permitAll()
+                .antMatchers("/members/**").hasAuthority("ROLE_GUEST")
+                .anyRequest().authenticated()
+                .and()
+
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+                .and()
+
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOriginPatterns(List.of(ALL));
+        config.setAllowedMethods(List.of(ALL));
+        config.setAllowedHeaders(List.of(ALL));
+        config.setAllowCredentials(true);
+        config.setExposedHeaders(List.of("Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -1,0 +1,35 @@
+package wegrus.clubwebsite.dto.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INTERNAL_SERVER_ERROR(500, "C000", "내부 서버 오류입니다."),
+    INVALID_INPUT_VALUE(400, "C001", "유효하지 않은 입력입니다."),
+    EXPIRED_ACCESS_TOKEN(401, "C002", "만료된 Access Token입니다."),
+    EXPIRED_REFRESH_TOKEN(401, "C003", "만료된 Refresh Token입니다."),
+    INVALID_JWT(401, "C004", "유효하지 않은 JWT입니다."),
+    INVALID_AUTHORIZATION_HEADER(400, "C005", "유효하지 않은 인증 헤더입니다."),
+    REFRESH_TOKEN_NOT_MATCH(400, "C006", "Refresh Token이 일치하지 않습니다."),
+    SIGNATURE_NOT_MATCH(400, "C006", "JWT의 Signature이 일치하지 않습니다."),
+    METHOD_NOT_ALLOWED(405, "C007", "허용되지 않은 HTTP method입니다."),
+    INVALID_TYPE_VALUE(400, "C008", "입력 타입이 유효하지 않습니다."),
+    INSUFFICIENT_AUTHORITY(403, "C009", "접근 권한이 부족합니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(400, "M000", "존재하지 않는 회원입니다."),
+    KAKAOID_ALREADY_EXIST(400, "M001", "이미 존재하는 카카오 회원 번호입니다."),
+    EMAIL_ALREADY_EXIST(400, "M002", "이미 존재하는 이메일입니다."),
+
+    // Verification
+    EXPIRED_VERIFICATION_KEY(400, "V000", "만료된 인증 키입니다."),
+    ;
+
+    private int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorResponse.java
@@ -1,0 +1,99 @@
+package wegrus.clubwebsite.dto.error;
+
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.errors = errors;
+        this.code = code.getCode();
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+        return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+    public static ErrorResponse of(ConstraintViolationException e) {
+        final List<FieldError> errors = new ArrayList<FieldError>();
+        Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
+        if (constraintViolations != null) {
+            for (ConstraintViolation c : constraintViolations) {
+                final String pathStr = c.getPropertyPath().toString();
+                final String[] paths = pathStr.split("\\.");
+                final String path = paths.length > 0 ? paths[paths.length - 1] : paths[0];
+                final String fieldName = path;
+                final String requestedValue = c.getInvalidValue() == null ? "" : c.getInvalidValue().toString();
+                final String message = c.getMessage();
+                errors.add(new FieldError(fieldName, requestedValue, message));
+            }
+        }
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+    @Getter
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        public FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -1,0 +1,23 @@
+package wegrus.clubwebsite.dto.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+
+    // Member
+    SIGNUP_SUCCESS(200, "M100", "회원가입에 성공하였습니다."),
+    LOGIN_SUCCESS(200, "M101", "로그인에 성공하였습니다."),
+    LOGOUT_SUCCESS(200, "M102", "로그아웃에 성공하였습니다."),
+
+    // Verification
+    REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),
+    VERIFY_EMAIL_SUCCESS(200, "V101", "이메일 인증에 성공하였습니다."),
+    ;
+
+    private int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultResponse.java
@@ -1,0 +1,30 @@
+package wegrus.clubwebsite.dto.result;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@ApiModel(description = "결과 응답 데이터 모델")
+@Getter
+public class ResultResponse {
+
+    @ApiModelProperty(value = "Http 상태 코드")
+    private int status;
+    @ApiModelProperty(value = "Business 상태 코드")
+    private String code;
+    @ApiModelProperty(value = "응답 메세지")
+    private String message;
+    @ApiModelProperty(value = "응답 데이터")
+    private Object data;
+
+    public static ResultResponse of(ResultCode resultCode, Object data){
+        return new ResultResponse(resultCode, data);
+    }
+
+    public ResultResponse(ResultCode resultCode, Object data) {
+        this.status = resultCode.getStatus();
+        this.code = resultCode.getCode();
+        this.message = resultCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/BusinessException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/BusinessException.java
@@ -1,0 +1,31 @@
+package wegrus.clubwebsite.exception;
+
+import lombok.Getter;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private List<ErrorResponse.FieldError> errors = new ArrayList<>();
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, List<ErrorResponse.FieldError> errors) {
+        super(errorCode.getMessage());
+        this.errors = errors;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/util/JwtTokenUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtTokenUtil.java
@@ -1,0 +1,87 @@
+package wegrus.clubwebsite.util;
+
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import wegrus.clubwebsite.exception.RefreshTokenExpiredException;
+import wegrus.clubwebsite.exception.JwtInvalidException;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Slf4j
+@Component
+public class JwtTokenUtil {
+
+    @Value("${jwt.access.validity}")
+    private long ACCESS_TOKEN_VALIDITY;
+    @Value("${jwt.refresh.validity}")
+    private long REFRESH_TOKEN_VALIDITY;
+
+    @Value("${jwt.access.secret}")
+    private String ACCESS_TOKEN_SECRET;
+    @Value("${jwt.refresh.secret}")
+    private String REFRESH_TOKEN_SECRET;
+
+    public String getUsernameFromAccessToken(String token) {
+        return getClaimFromAccessToken(token, Claims::getSubject);
+    }
+
+    public <T> T getClaimFromAccessToken(String token, Function<Claims, T> claimsResolver) {
+        Claims claims = getAllClaimsFromAccessToken(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims getAllClaimsFromAccessToken(String token) {
+        return Jwts.parser().setSigningKey(ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody();
+    }
+
+    public String generateAccessToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "AccessToken");
+        return doGenerateToken(claims, headers, userDetails.getUsername(), ACCESS_TOKEN_VALIDITY, ACCESS_TOKEN_SECRET);
+    }
+
+    public String generateRefreshToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "RefreshToken");
+        return doGenerateToken(claims, headers, userDetails.getUsername(), REFRESH_TOKEN_VALIDITY, REFRESH_TOKEN_SECRET);
+    }
+
+    private String doGenerateToken(Map<String, Object> claims, Map<String, Object> headers, String subject, long validity, String secret) {
+        return Jwts.builder()
+                .setHeader(headers)
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + validity))
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+    }
+
+    public Boolean validateAccessToken(String token) {
+        return validateToken(token, ACCESS_TOKEN_SECRET);
+    }
+
+    public void validateRefreshToken(String token) {
+        if (!validateToken(token, REFRESH_TOKEN_SECRET))
+            throw new RefreshTokenExpiredException();
+    }
+
+    private Boolean validateToken(String token, String secret) {
+        try {
+            Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return false;
+        } catch (JwtException e) {
+            throw new JwtInvalidException();
+        }
+        return true;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
@@ -1,0 +1,35 @@
+package wegrus.clubwebsite.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import wegrus.clubwebsite.entity.Member;
+import wegrus.clubwebsite.exception.MemberNotFoundException;
+import wegrus.clubwebsite.repository.MemberRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JwtUserDetailsUtil implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) {
+        Member findMember = memberRepository.findById(Long.valueOf(id)).orElseThrow(MemberNotFoundException::new);
+
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add((GrantedAuthority) () -> String.valueOf(findMember.getRole()));
+        return new User(String.valueOf(findMember.getId()),
+                UUID.randomUUID().toString(),
+                new ArrayList<>(authorities));
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/util/RedisUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/RedisUtil.java
@@ -1,0 +1,30 @@
+package wegrus.clubwebsite.util;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class RedisUtil {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    public void set(String key, Object o, int minutes) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
+        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+        return redisTemplate.delete(key);
+    }
+
+    public boolean hasKey(String key) { return redisTemplate.hasKey(key); }
+}

--- a/src/test/java/wegrus/clubwebsite/ClubWebsiteApplicationTests.java
+++ b/src/test/java/wegrus/clubwebsite/ClubWebsiteApplicationTests.java
@@ -3,7 +3,7 @@ package wegrus.clubwebsite;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class ClubWebsiteApplicationTests {
 
 	@Test


### PR DESCRIPTION
## PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #8 
- Resolve #9 

## PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### Redis 도입
- 이메일 인증 키(30분), Refresh Token(2주) Redis Cache in Memory에 저장
- DB보다 빠르게 접근 가능, 유효 시간 만료 시 자동 삭제
- Redis 설정 클래스, 유틸 클래스 추가

### Spring Security 도입
- Spring Security는 보안과 관련해서 체계적으로 많은 옵션을 제공
- Interceptor가 Dispatcher Servlet과 Controller사이에 위치하여 Controller 진입 전 인증, 인가에 대한 필터링 적용을 편리하게 가능
- Security 설정 클래스 추가

### 예외 처리 핸들러 도입
- GlobalExceptionHandler에서 표준 예외, 비지니스 예외 처리를 담당
- 비즈니스 예외 추가 시, 간단히 BusinessException만 상속받으면 자동으로 핸들러에 등록 됨

### ErrorCode, ErrorResponse, ResultCode, ResultResponse 추가
- RestController 응답 시, ResponseEntity의 body 부분에 ResultResponse를 담아주시면 됩니다.
- ErrorResponse는 예외 처리 핸들러에서 다루므로, 따로 작업하실 필요는 없습니다.
- ErrorCode, ResultCode는 (Http Code, Business Code, message)로 이루어져 있고, 추가하실 때는 카테고리별로 주석을 달아서 작성 바랍니다.

### Json Web Token 도입
- 사용자 인증에 대한 정보가 토큰에 포함되기 떄문에 별도의 인증 저장소가 필요 없음 -> 서버 자원 절감
- 분산 마이크로 서비스 환경에서 중앙 집중식 인증 서버와 데이터베이스에 의존하지 않는 쉬운 인증 및 인가 방법을 제공
- 현 프로젝트에서는 회원 인증 시 사용
- AccessToken & RefreshToken 방식 적용
    - api 호출 마다 Authorization 헤더에 AccessToken을 담아 요청하고, 만료 시에는 RefreshToken으로 재발급 요청하는 흐름.

### AWS 배포 관련 에러 해결
- Linux에서 `./gradlew build` 실행 시, xx.jar, xx-plain.jar이 함께 생성되고, 배포 스크립트에 *.jar을 실행하도록 작성해놔서 `no main manifest attribute in` 에러가 발생했습니다.
- 따라서 xx-plain.jar이 생성되지 않도록 build.gradle에 명령어를 추가해 주었습니다.
- 그리고 아직 테스트 디렉토리에 설정 파일을 추가하지 않아서, Context Load 시 에러가 발생하길래 일단 주석처리 해 놓았습니다.

## Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- Commit 단위로 확인해 주시고, Commit에 관련 내용 첨언되어 있으니 확인 바랍니다.
- 코드 확인하신 후에 궁금한 부분이나 논의할 부분이 있으면 Comment 남겨주시면 됩니다.
- Redis, Security, Jwt 관련해서 잘 아시는 부분이 있으시면 공유바랍니다.🙂
### JWT 보안적 고려사항
- Access Token 만료시간을 짧게(30분)으로 하여 탈취 가능성을 감소시킴
- Front-end에서 AccessToken은 Memory(변수)에 저장하고, XSS 공격 방지를 위해 RefreshToken을 cookie에 저장한 후, `HTTP Only`, `Secure Cookie` 옵션 적용.
- CSRF 공격 방지를 위해 cookie에 anti-CSRF token을 포함하고, Samesite 옵션을 적용
- 로그인 api 응답으로 accessToken은 Response Body에, refreshToken은 cookie에 담아서 전달
- 보안 부분은 이후 업데이트 할 예정

## References
> 참고한 사이트가 있다면 공유해주세요.

- [JWT 보안](https://hshine1226.medium.com/localstorage-vs-cookies-jwt-%ED%86%A0%ED%81%B0%EC%9D%84-%EC%95%88%EC%A0%84%ED%95%98%EA%B2%8C-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B8%B0-%EC%9C%84%ED%95%B4-%EC%95%8C%EC%95%84%EC%95%BC%ED%95%A0-%EB%AA%A8%EB%93%A0%EA%B2%83-4fb7fb41327c)

## Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
