### PR TITLE
Role 엔티티 추가 및 회원가입, 로그인 API 응답 데이터 수정

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -1,0 +1,24 @@
+package wegrus.clubwebsite.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.entity.member.Role;
+import wegrus.clubwebsite.repository.RoleRepository;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+@RequiredArgsConstructor
+public class SetupConfig {
+
+    private final RoleRepository roleRepository;
+
+    @PostConstruct
+    private void setup() {
+        if (roleRepository.findAll().isEmpty()) {
+            for (MemberRoles role : MemberRoles.values())
+                roleRepository.save(new Role(role.name()));
+        }
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -48,8 +48,7 @@ public class MemberController {
     @ApiImplicitParam(name = "Authorization", value = "불필요", example = " ")
     @PostMapping("/signup")
     public ResponseEntity<ResultResponse> signup(@Validated @RequestBody MemberSignupRequest request) throws MessagingException {
-        final String verificationKey = memberService.validateAndSendVerificationMailAndSaveMember(request);
-        final MemberSignupResponse response = new MemberSignupResponse(verificationKey);
+        final MemberSignupResponse response = memberService.validateAndSendVerificationMailAndSaveMember(request);
 
         return ResponseEntity.ok(ResultResponse.of(SIGNUP_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(400, "M000", "존재하지 않는 회원입니다."),
     KAKAOID_ALREADY_EXIST(400, "M001", "이미 존재하는 카카오 회원 번호입니다."),
     EMAIL_ALREADY_EXIST(400, "M002", "이미 존재하는 이메일입니다."),
-    INVALID_EMAIL(400, "M002", "인하대학교 이메일 형식만 가능합니다."),
+    INVALID_EMAIL(400, "M003", "인하대학교 이메일 형식만 가능합니다."),
+    MEMBER_ROLE_NOT_FOUND(400, "M004", "존재하지 않는 회원 등급입니다."),
     ;
 
     private int status;

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberAndJwtDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberAndJwtDto.java
@@ -3,14 +3,13 @@ package wegrus.clubwebsite.dto.member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import wegrus.clubwebsite.entity.member.Member;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberAndJwtDto {
 
-    private Member member;
+    private MemberDto member;
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberDto.java
@@ -1,0 +1,47 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDto {
+
+    private String email;
+    private String name;
+    private String studentId;
+    private String department;
+    private MemberGrade grade;
+    private String phone;
+    private LocalDateTime createdDate;
+    private String introduce;
+    private String imageUrl;
+    private MemberAcademicStatus academicStatus;
+    private List<String> roles = new ArrayList<>();
+
+    public MemberDto(Member member) {
+        this.email = member.getEmail();
+        this.name = member.getName();
+        this.studentId = member.getStudentId();
+        this.department = member.getDepartment();
+        this.grade = member.getGrade();
+        this.phone = member.getPhone();
+        this.createdDate = member.getCreatedDate();
+        this.introduce = member.getIntroduce();
+        this.imageUrl = member.getImageUrl();
+        this.academicStatus = member.getAcademicStatus();
+        member.getRoles().stream()
+                .map(r -> this.roles.add(r.getRole().getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSigninSuccessResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSigninSuccessResponse.java
@@ -3,7 +3,6 @@ package wegrus.clubwebsite.dto.member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import wegrus.clubwebsite.entity.member.Member;
 
 @Getter
 @AllArgsConstructor
@@ -11,6 +10,6 @@ import wegrus.clubwebsite.entity.member.Member;
 public class MemberSigninSuccessResponse {
 
     private String status;
-    private Member member;
+    private MemberDto member;
     private String accessToken;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupResponse.java
@@ -9,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberSignupResponse {
 
+    private MemberDto member;
     private String verificationKey;
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -14,7 +14,9 @@ import wegrus.clubwebsite.entity.board.View;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -46,9 +48,8 @@ public class Member {
     @Column(name = "member_email", unique = true, nullable = false)
     private String email;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "member_role", nullable = false)
-    private MemberRole role;
+    @OneToMany(mappedBy = "member")
+    private Set<MemberRole> roles = new LinkedHashSet<>();
 
     @Column(name = "member_name", nullable = false)
     private String name;
@@ -72,7 +73,7 @@ public class Member {
 
     @Lob
     @Column(name = "member_introduce")
-    private String introduce;
+    private String introduce = "";
 
     @Column(name = "member_image_url")
     private String imageUrl;
@@ -82,19 +83,14 @@ public class Member {
     private MemberAcademicStatus academicStatus;
 
     @Builder
-    public Member(Long kakaoId, String email, String name, String studentId, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus) {
+    public Member(Long kakaoId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus) {
         this.kakaoId = kakaoId;
         this.email = email;
         this.name = name;
-        this.studentId = studentId;
+        this.studentId = email.substring(0, 8);
         this.department = department;
         this.grade = grade;
         this.phone = phone;
         this.academicStatus = academicStatus;
-        this.role = MemberRole.ROLE_GUEST;
-    }
-
-    public void updateRole(MemberRole role){
-        this.role = role;
     }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberRole.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberRole.java
@@ -1,5 +1,34 @@
 package wegrus.clubwebsite.entity.member;
 
-public enum MemberRole {
-    ROLE_GUEST, ROLE_CERTIFIED, ROLE_MEMBER, ROLE_MANAGER
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_roles")
+public class MemberRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_role_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Builder
+    public MemberRole(Member member, Role role) {
+        this.member = member;
+        this.role = role;
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
@@ -1,0 +1,5 @@
+package wegrus.clubwebsite.entity.member;
+
+public enum MemberRoles {
+    ROLE_GUEST, ROLE_CERTIFIED, ROLE_MEMBER, ROLE_ADMIN
+}

--- a/src/main/java/wegrus/clubwebsite/entity/member/Role.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Role.java
@@ -1,0 +1,26 @@
+package wegrus.clubwebsite.entity.member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id")
+    private Long id;
+
+    @Column(name = "role_name", unique = true)
+    private String name;
+
+    public Role(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/MemberRoleNotFoundException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberRoleNotFoundException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class MemberRoleNotFoundException extends BusinessException{
+
+    public MemberRoleNotFoundException() {
+        super(ErrorCode.MEMBER_ROLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
@@ -1,0 +1,7 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.member.MemberRole;
+
+public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+}

--- a/src/main/java/wegrus/clubwebsite/repository/RoleRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.member.Role;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}

--- a/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
@@ -2,12 +2,14 @@ package wegrus.clubwebsite.util;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.member.MemberRole;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.repository.MemberRepository;
 
@@ -27,7 +29,9 @@ public class JwtUserDetailsUtil implements UserDetailsService {
         Member findMember = memberRepository.findById(Long.valueOf(id)).orElseThrow(MemberNotFoundException::new);
 
         List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add((GrantedAuthority) () -> String.valueOf(findMember.getRole()));
+        for (MemberRole role : findMember.getRoles())
+            authorities.add(new SimpleGrantedAuthority(role.getRole().getName()));
+
         return new User(String.valueOf(findMember.getId()),
                 UUID.randomUUID().toString(),
                 new ArrayList<>(authorities));

--- a/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
@@ -40,7 +40,6 @@ public class BoardRepositoryTest {
     public void boardSaveLoad(){
         final Member member = Member.builder()
                 .name("김철수")
-                .studentId("12191634")
                 .department("컴퓨터공학과")
                 .grade(MemberGrade.JUNIOR)
                 .kakaoId((long) 987654321)

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -21,10 +21,7 @@ import wegrus.clubwebsite.config.WebSecurityConfig;
 import wegrus.clubwebsite.controller.MemberController;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.VerificationResponse;
-import wegrus.clubwebsite.dto.member.EmailCheckResponse;
-import wegrus.clubwebsite.dto.member.JwtDto;
-import wegrus.clubwebsite.dto.member.MemberAndJwtDto;
-import wegrus.clubwebsite.dto.member.MemberSignupRequest;
+import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
@@ -145,7 +142,9 @@ public class MemberControllerTest {
     void signup_success() throws Exception {
         // given
         final String verificationKey = UUID.randomUUID().toString();
-        doReturn(verificationKey).when(memberService).validateAndSendVerificationMailAndSaveMember(any(MemberSignupRequest.class));
+        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final MemberSignupResponse response = new MemberSignupResponse(new MemberDto(member), verificationKey);
+        doReturn(response).when(memberService).validateAndSendVerificationMailAndSaveMember(any(MemberSignupRequest.class));
         final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", 123456789L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
 
         // when
@@ -216,10 +215,10 @@ public class MemberControllerTest {
     @DisplayName("로그인 API: 성공")
     void login_success() throws Exception {
         // given
-        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "12161111", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
         final String accessToken = "accessToken";
         final String refreshToken = "refreshToken";
-        final MemberAndJwtDto dto = new MemberAndJwtDto(member, accessToken, refreshToken);
+        final MemberAndJwtDto dto = new MemberAndJwtDto(new MemberDto(member), accessToken, refreshToken);
 
         doReturn(dto).when(memberService).findMemberAndGenerateJwt(any(Long.class));
 
@@ -236,7 +235,6 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("code").value(SIGNIN_SUCCESS.getCode()))
                 .andExpect(jsonPath("message").value(SIGNIN_SUCCESS.getMessage()))
                 .andExpect(jsonPath("data.status").value(Status.SUCCESS))
-                .andExpect(jsonPath("data.member.kakaoId").value(123456789L))
                 .andExpect(jsonPath("data.accessToken").value(accessToken))
                 .andExpect(cookie().value("refreshToken", refreshToken))
                 .andExpect(cookie().httpOnly("refreshToken", true))

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -16,7 +16,7 @@ import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
-import wegrus.clubwebsite.entity.member.MemberRole;
+import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.util.RedisUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,8 +161,7 @@ public class MemberIntegrationTest {
         assertThat(responseEntity.getHeaders().get("Set-Cookie").get(0)).isNotBlank();
         assertThat(response.getStatus()).isEqualTo(Status.SUCCESS);
         assertThat(response.getAccessToken()).isNotBlank();
-        assertThat(response.getMember().getKakaoId()).isEqualTo(kakaoId);
-        assertThat(response.getMember().getRole()).isEqualTo(MemberRole.ROLE_CERTIFIED);
+        assertThat(response.getMember().getRoles().contains(MemberRoles.ROLE_CERTIFIED.name())).isTrue();
     }
 
     @Test

--- a/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
@@ -29,7 +29,6 @@ public class MemberRepositoryTest {
                     .academicStatus(i % 2 == 1 ? MemberAcademicStatus.ATTENDING : MemberAcademicStatus.ABSENCE)
                     .phone("010-1234-567" + i)
                     .kakaoId((long) (1234567 + i))
-                    .studentId("1216154" + i)
                     .grade(MemberGrade.FRESHMAN)
                     .build();
 


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #19 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

- Member 권한을 리스트 형태로 관리하기 위해 관련 엔티티가 추가되었습니다.
    - ManyToMany는 여러 단점들이 존재하기에, OneToMany, ManyToOne 관계로 나누는 방식을 선택하였습니다.
    - **ManyToMany 단점**
        - 편리해 보이지만 실무에서 사용하면 안된다.
        - 개발하다 보면, 연결 테이블이 단순히 연결만 하고 끝나지 않는다. 조인 테이블 자체에 주문시간, 수량 같은 추가 데이터가 많이 들어갈 수 있다.
        - 매핑 정보를 넣는 것만 가능하고, 추가 정보를 넣는 것 자체가 불가능하다.
        - 그리고 중간 테이블이 숨겨져 있기 때문에 예상하지 못하는 쿼리들이 나간다.
        - 이런 문제점들 때문에 실무에서는 안쓰는게 맞다고 본다.
        > 출처: 김영한님
- 프론트단에서 Redux로 상태 관리를 용이하게 하기 위해 회원가입과 로그인 API 응답 데이터에 회원 정보를 추가하였습니다.
    - 또한, 지난 PR(#14)에서 회원 엔티티에 OneToMany 관계가 추가되어, 엔티티를 그대로 응답 시 지연로딩으로 인한 null 값이 반환되기 때문에 에러가 발생합니다. 엔티티에 @JsonIgnore를 추가하는 것은 좋지 않은 설계라고 생각하고, DTO로 변환하여 응답하는 것이 깔끔하기 때문에 DTO로 변환해서 응답하였습니다.
- 회원 생성자에서 학번 파라미터를 제거하였습니다.
    - 기존에는 Service 단에서 이메일을 파싱하여 저장하였지만, 테스트 코드 작성 시 불편함이 있어서, 생성자 단에서 이메일을 파싱하여 저장하는 방식으로 변경하였습니다.

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
