### PR TITLE
회원 정보 수정 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'com.querydsl:querydsl-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.4.RELEASE'
 	implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -131,4 +131,12 @@ public class MemberController {
 
         return ResponseEntity.ok(ResultResponse.of(GET_MEMBER_INFO_SUCCESS, response));
     }
+
+    @ApiOperation(value = "회원 정보 수정")
+    @PatchMapping("/members/info")
+    public ResponseEntity<ResultResponse> updateInfo(@Validated @RequestBody MemberInfoUpdateRequest request) {
+        final MemberInfoUpdateResponse response = memberService.updateMemberInfo(request);
+
+        return ResponseEntity.ok(ResultResponse.of(UPDATE_MEMBER_INFO_SUCCESS, response));
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateRequest.java
@@ -37,4 +37,7 @@ public class MemberInfoUpdateRequest {
     @ApiModelProperty(value = "회원 학년", example = "FRESHMAN", required = true)
     @NotNull(message = "회원 학년은 필수입니다.")
     private MemberGrade grade;
+
+    @ApiModelProperty(value = "회원 소개", example = "안녕하세요.", required = true)
+    private String introduce;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateRequest.java
@@ -1,0 +1,40 @@
+package wegrus.clubwebsite.dto.member;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@ApiModel(description = "회원 정보 수정 요청 데이터 모델")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoUpdateRequest {
+
+    @ApiModelProperty(value = "회원 실명", example = "홍길동", required = true)
+    @NotBlank(message = "회원 실명은 필수입니다.")
+    private String name;
+
+    @ApiModelProperty(value = "회원 학과", example = "컴퓨터공학과", required = true)
+    @NotBlank(message = "회원 학과는 필수입니다.")
+    private String department;
+
+    @ApiModelProperty(value = "회원 연락처", example = "010-1234-5678", required = true)
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "연락처는 010-1234-5678 형식으로 입력해주세요.")
+    private String phone;
+
+    @ApiModelProperty(value = "회원 학적 상태", example = "ATTENDING", required = true)
+    @NotNull(message = "회원 학적 상태는 필수입니다.")
+    private MemberAcademicStatus academicStatus;
+
+    @ApiModelProperty(value = "회원 학년", example = "FRESHMAN", required = true)
+    @NotNull(message = "회원 학년은 필수입니다.")
+    private MemberGrade grade;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateResponse.java
@@ -16,6 +16,7 @@ public class MemberInfoUpdateResponse {
     private String name;
     private String department;
     private String phone;
+    private String introduce;
     private MemberAcademicStatus academicStatus;
     private MemberGrade grade;
 
@@ -26,5 +27,6 @@ public class MemberInfoUpdateResponse {
         this.phone = member.getPhone();
         this.academicStatus = member.getAcademicStatus();
         this.grade = member.getGrade();
+        this.introduce = member.getIntroduce();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberInfoUpdateResponse.java
@@ -1,0 +1,30 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoUpdateResponse {
+
+    private String status;
+    private String name;
+    private String department;
+    private String phone;
+    private MemberAcademicStatus academicStatus;
+    private MemberGrade grade;
+
+    public MemberInfoUpdateResponse(String status, Member member) {
+        this.status = status;
+        this.name = member.getName();
+        this.department = member.getDepartment();
+        this.phone = member.getPhone();
+        this.academicStatus = member.getAcademicStatus();
+        this.grade = member.getGrade();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -16,6 +16,7 @@ public enum ResultCode {
     CHECK_EMAIL_SUCCESS(200, "M105", "이메일 검증에 성공하였습니다."),
     VALID_EMAIL(200, "M106", "사용 가능한 이메일입니다."),
     GET_MEMBER_INFO_SUCCESS(200, "M107", "회원 정보 조회에 성공하였습니다."),
+    UPDATE_MEMBER_INFO_SUCCESS(200, "M108", "회원 정보 수정에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -101,5 +101,6 @@ public class Member {
         this.phone = request.getPhone();
         this.department = request.getDepartment();
         this.academicStatus = request.getAcademicStatus();
+        this.introduce = request.getIntroduce();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import wegrus.clubwebsite.dto.member.MemberInfoUpdateRequest;
 import wegrus.clubwebsite.entity.board.Board;
 import wegrus.clubwebsite.entity.board.CommentLike;
 import wegrus.clubwebsite.entity.board.PostLike;
@@ -92,5 +93,13 @@ public class Member {
         this.grade = grade;
         this.phone = phone;
         this.academicStatus = academicStatus;
+    }
+
+    public void update(MemberInfoUpdateRequest request) {
+        this.name = request.getName();
+        this.grade = request.getGrade();
+        this.phone = request.getPhone();
+        this.department = request.getDepartment();
+        this.academicStatus = request.getAcademicStatus();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -150,4 +150,12 @@ public class MemberService {
         else
             return new MemberInfoResponse(Status.SUCCESS, new MemberSimpleDto(member));
     }
+
+    @Transactional
+    public MemberInfoUpdateResponse updateMemberInfo(MemberInfoUpdateRequest request) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        member.update(request);
+        return new MemberInfoUpdateResponse(Status.SUCCESS, member);
+    }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -37,8 +37,7 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static wegrus.clubwebsite.dto.error.ErrorCode.*;
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -444,5 +443,30 @@ public class MemberControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("code").value(MEMBER_NOT_FOUND.getCode()))
                 .andExpect(jsonPath("message").value(MEMBER_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 API: 성공")
+    void updateInfo_success() throws Exception {
+        // given
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-2424-2424", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final MemberInfoUpdateResponse response = new MemberInfoUpdateResponse(Status.SUCCESS, "만두", "정통", "010-2424-2424", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        doReturn(response).when(memberService).updateMemberInfo(any(MemberInfoUpdateRequest.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/members/info").with(csrf())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(UPDATE_MEMBER_INFO_SUCCESS.getCode()))
+                .andExpect(jsonPath("message").value(UPDATE_MEMBER_INFO_SUCCESS.getMessage()))
+                .andExpect(jsonPath("data.name").value("만두"))
+                .andExpect(jsonPath("data.department").value("정통"))
+                .andExpect(jsonPath("data.phone").value("010-2424-2424"));
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -449,8 +449,8 @@ public class MemberControllerTest {
     @DisplayName("회원 정보 수정 API: 성공")
     void updateInfo_success() throws Exception {
         // given
-        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-2424-2424", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
-        final MemberInfoUpdateResponse response = new MemberInfoUpdateResponse(Status.SUCCESS, "만두", "정통", "010-2424-2424", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-2424-2424", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, "안녕");
+        final MemberInfoUpdateResponse response = new MemberInfoUpdateResponse(Status.SUCCESS, "만두", "정통", "010-2424-2424", "안녕", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
         doReturn(response).when(memberService).updateMemberInfo(any(MemberInfoUpdateRequest.class));
 
         // when
@@ -467,6 +467,7 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("message").value(UPDATE_MEMBER_INFO_SUCCESS.getMessage()))
                 .andExpect(jsonPath("data.name").value("만두"))
                 .andExpect(jsonPath("data.department").value("정통"))
-                .andExpect(jsonPath("data.phone").value("010-2424-2424"));
+                .andExpect(jsonPath("data.phone").value("010-2424-2424"))
+                .andExpect(jsonPath("data.introduce").value("안녕"));
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -272,7 +272,7 @@ public class MemberIntegrationTest {
         final ResponseEntity<ResultResponse> responseEntity = signinAPI(151456339L);
         final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
         final String accessToken = memberSigninSuccessResponse.getAccessToken();
-        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-1234-1234", MemberAcademicStatus.ABSENCE, MemberGrade.FRESHMAN);
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-1234-1234", MemberAcademicStatus.ABSENCE, MemberGrade.FRESHMAN, "안녕");
 
         // when
         final MemberInfoUpdateResponse response = updateInfoAPI(accessToken, request);
@@ -281,5 +281,6 @@ public class MemberIntegrationTest {
         assertThat(response.getName()).isEqualTo("만두");
         assertThat(response.getDepartment()).isEqualTo("정통");
         assertThat(response.getAcademicStatus()).isEqualTo(MemberAcademicStatus.ABSENCE);
+        assertThat(response.getIntroduce()).isEqualTo("안녕");
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -104,7 +104,7 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(responseEntity.getBody().getData(), MemberInfoResponse.class);
     }
 
-    public MemberInfoUpdateResponse updateInfo(String accessToken, MemberInfoUpdateRequest memberInfoUpdateRequest) {
+    public MemberInfoUpdateResponse updateInfoAPI(String accessToken, MemberInfoUpdateRequest memberInfoUpdateRequest) {
         HttpHeaders headers = new HttpHeaders();
         headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
 
@@ -264,7 +264,7 @@ public class MemberIntegrationTest {
     
     @Test
     @DisplayName("회원 정보 수정")
-    void updateInfo() throws Exception {
+    void updateInfoAPI() throws Exception {
         // given
         final MemberSignupResponse memberSignupResponse = signupAPI("24344311@inha.edu", 151456339L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
         final String verificationKey = memberSignupResponse.getVerificationKey();
@@ -275,7 +275,7 @@ public class MemberIntegrationTest {
         final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-1234-1234", MemberAcademicStatus.ABSENCE, MemberGrade.FRESHMAN);
 
         // when
-        final MemberInfoUpdateResponse response = updateInfo(accessToken, request);
+        final MemberInfoUpdateResponse response = updateInfoAPI(accessToken, request);
 
         // then
         assertThat(response.getName()).isEqualTo("만두");

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -264,7 +264,7 @@ public class MemberIntegrationTest {
     
     @Test
     @DisplayName("회원 정보 수정")
-    void updateInfoAPI() throws Exception {
+    void updateInfo() throws Exception {
         // given
         final MemberSignupResponse memberSignupResponse = signupAPI("24344311@inha.edu", 151456339L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
         final String verificationKey = memberSignupResponse.getVerificationKey();

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -104,6 +104,15 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(responseEntity.getBody().getData(), MemberInfoResponse.class);
     }
 
+    public MemberInfoUpdateResponse updateInfo(String accessToken, MemberInfoUpdateRequest memberInfoUpdateRequest) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+        final HttpEntity<MemberInfoUpdateRequest> request = new HttpEntity<>(memberInfoUpdateRequest, headers);
+        final ResponseEntity<ResultResponse> responseEntity = restTemplate.exchange("/members/info", HttpMethod.PATCH, request, ResultResponse.class);
+        return objectMapper.convertValue(responseEntity.getBody().getData(), MemberInfoUpdateResponse.class);
+    }
+
     @Test
     @DisplayName("이메일 검증")
     void checkEmail() throws Exception {
@@ -251,5 +260,26 @@ public class MemberIntegrationTest {
         // then
         assertThat(info.getStudentId()).isEqualTo("12344379");
         assertThat(info2.getStudentId()).isEqualTo("44");
+    }
+    
+    @Test
+    @DisplayName("회원 정보 수정")
+    void updateInfo() throws Exception {
+        // given
+        final MemberSignupResponse memberSignupResponse = signupAPI("24344311@inha.edu", 151456339L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String verificationKey = memberSignupResponse.getVerificationKey();
+        verifySchoolEmailAPI(verificationKey);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI(151456339L);
+        final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
+        final String accessToken = memberSigninSuccessResponse.getAccessToken();
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-1234-1234", MemberAcademicStatus.ABSENCE, MemberGrade.FRESHMAN);
+
+        // when
+        final MemberInfoUpdateResponse response = updateInfo(accessToken, request);
+
+        // then
+        assertThat(response.getName()).isEqualTo("만두");
+        assertThat(response.getDepartment()).isEqualTo("정통");
+        assertThat(response.getAcademicStatus()).isEqualTo(MemberAcademicStatus.ABSENCE);
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
@@ -273,4 +273,23 @@ public class MemberServiceTest {
         // then
         assertThrows(MemberNotFoundException.class, executable);
     }
+
+    @Test
+    @DisplayName("회원 정보 수정: 성공")
+    void updateMemberInfo_success() throws Exception {
+        // given
+        final Optional<Member> member = Optional.of(new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        ReflectionTestUtils.setField(member.get(), "id", 1L);
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-3333-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
+        doReturn(member).when(memberRepository).findById(any(Long.class));
+
+        // when
+        final MemberInfoUpdateResponse response = memberService.updateMemberInfo(request);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(Status.SUCCESS);
+        assertThat(response.getName()).isEqualTo("만두");
+        assertThat(response.getDepartment()).isEqualTo("정통");
+        assertThat(response.getPhone()).isEqualTo("010-3333-1234");
+    }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
@@ -280,7 +280,7 @@ public class MemberServiceTest {
         // given
         final Optional<Member> member = Optional.of(new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
         ReflectionTestUtils.setField(member.get(), "id", 1L);
-        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-3333-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
+        final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-3333-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "안녕");
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         // when
@@ -291,5 +291,6 @@ public class MemberServiceTest {
         assertThat(response.getName()).isEqualTo("만두");
         assertThat(response.getDepartment()).isEqualTo("정통");
         assertThat(response.getPhone()).isEqualTo("010-3333-1234");
+        assertThat(response.getIntroduce()).isEqualTo("안녕");
     }
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #22 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

- 마이페이지, 동아리 가입 신청 페이지에서 사용
- 실명, 학과, 연락처, 학적 상태, 학년, 소개만 변경 가능
- RestTemplate에서 Patch, Put 메소드 사용을 위해 라이브러리 추가.

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- `회원 탈퇴 API`는 논의할 부분이 있어서 일단 보류하려 합니다.
    1. 기존 글, 댓글 제거 + 재가입 불가
    2. 기존 글, 댓글 유지 + 재가입 불가
    3. 기존 글, 댓글 제거 + 재가입 허용
    4. ✅기존 글, 댓글 유지 + 재가입 허용 + 기존 글, 댓글 수정/삭제 가능
    5. 기존 글, 댓글 유지 + 재가입 시, 새 아이디 제공 -> 기존 글, 댓글 수정/삭제 불가 (로직 변경 多)
- MemberRoles에 ROLE_NONE을 추가하여 회원 탈퇴 시 해당 권한만 남겨 놓고 모두 제거?
    - ROLE_NONE인 사람의 회원 정보 조회 -> 불가능하게 막기 + 개인정보 파기

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- [reference 1](https://soye0n.tistory.com/117)

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
