### PR TITLE
회원 API 로직 변경

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -48,7 +48,7 @@ public class MemberController {
         return ResponseEntity.ok(ResultResponse.of(REQUEST_VERIFY_SUCCESS, response));
     }
 
-    @ApiOperation(value = "회원 가입")
+    @ApiOperation(value = "회원 가입", notes = "이메일 검증 API에서 받은 토큰과 함께 요청해주세요.")
     @ApiImplicitParam(name = "Authorization", value = "불필요", example = " ")
     @PostMapping("/signup")
     public ResponseEntity<ResultResponse> signup(@Validated @RequestBody MemberSignupRequest request) throws MessagingException {
@@ -60,14 +60,14 @@ public class MemberController {
     @ApiOperation(value = "로그인")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "불필요", example = " "),
-            @ApiImplicitParam(name = "kakaoId", value = "카카오 회원 번호", required = true, example = "123456789")
+            @ApiImplicitParam(name = "authorizationCode", value = "카카오 인증 코드", required = true, example = "ASKDJASIN12231KNsakdasdl1210SSALadk5234")
     })
     @PostMapping("/signin")
     public ResponseEntity<ResultResponse> signin(
-            @Validated @NotNull(message = "카카오 회원 번호는 필수입니다.") @RequestParam Long kakaoId,
+            @Validated @NotBlank(message = "카카오 인증 코드는 필수입니다.") @RequestParam String authorizationCode,
             HttpServletResponse httpServletResponse) {
         try {
-            final MemberAndJwtDto dto = memberService.findMemberAndGenerateJwt(kakaoId);
+            final MemberAndJwtDto dto = memberService.findMemberAndGenerateJwt(authorizationCode);
             final MemberSigninSuccessResponse response = new MemberSigninSuccessResponse(Status.SUCCESS, dto.getMember(), dto.getAccessToken());
             putRefreshTokenToCookie(httpServletResponse, dto.getRefreshToken());
 
@@ -115,7 +115,7 @@ public class MemberController {
         return ResponseEntity.ok(ResultResponse.of(REISSUE_SUCCESS, response));
     }
 
-    @ApiOperation(value = "이메일 검증")
+    @ApiOperation(value = "이메일 검증", notes = "이메일 중복 체크와 검증에 성공하면 토큰을 획득하며, 유효시간은 30분입니다.")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "불필요", example = " "),
             @ApiImplicitParam(name = "email", value = "이메일", required = true, example = "12161542@inha.edu")
@@ -147,7 +147,7 @@ public class MemberController {
     @ApiOperation(value = "회원 이미지 변경")
     @ApiImplicitParam(name = "multipartFile", value = "회원 이미지")
     @PatchMapping(value = "/members/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResultResponse> updateImage(@RequestPart(required = false) MultipartFile image) throws IOException {
+    public ResponseEntity<ResultResponse> updateImage(@RequestPart(required = false, name = "image") MultipartFile image) throws IOException {
         final MemberImageUpdateResponse response = memberService.updateMemberImage(image);
 
         return ResponseEntity.ok(ResultResponse.of(UPDATE_MEMBER_IMAGE_SUCCESS, response));

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -29,11 +29,12 @@ public enum ErrorCode {
 
     // Member
     MEMBER_NOT_FOUND(400, "M000", "존재하지 않는 회원입니다."),
-    KAKAOID_ALREADY_EXIST(400, "M001", "이미 존재하는 카카오 회원 번호입니다."),
+    USERID_ALREADY_EXIST(400, "M001", "이미 존재하는 아이디입니다."),
     EMAIL_ALREADY_EXIST(400, "M002", "이미 존재하는 이메일입니다."),
     INVALID_EMAIL(400, "M003", "인하대학교 이메일 형식만 가능합니다."),
     MEMBER_ROLE_NOT_FOUND(400, "M004", "존재하지 않는 회원 등급입니다."),
     MEMBER_IMAGE_ALREADY_BASIC(400, "M005", "회원 이미지가 이미 기본 이미지입니다."),
+    EMAIL_CERTIFICATION_TOKEN_INVALID(400, "M006", "이메일 검증 토큰이 유효하지 않습니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/member/EmailCheckResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/EmailCheckResponse.java
@@ -11,4 +11,10 @@ public class EmailCheckResponse {
 
     private String status;
     private String reason;
+    private String token = "";
+
+    public EmailCheckResponse(String status, String reason) {
+        this.status = status;
+        this.reason = reason;
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/EmailCheckResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/EmailCheckResponse.java
@@ -11,7 +11,7 @@ public class EmailCheckResponse {
 
     private String status;
     private String reason;
-    private String token = "";
+    private String verificationKey = "";
 
     public EmailCheckResponse(String status, String reason) {
         this.status = status;

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSigninFailResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSigninFailResponse.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class MemberSigninFailResponse {
 
     private String status;
+    private String userId;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
@@ -45,8 +45,8 @@ public class MemberSignupRequest {
     @ApiModelProperty(value = "회원 학년", example = "FRESHMAN", required = true)
     @NotNull(message = "회원 학년은 필수입니다.")
     private MemberGrade grade;
-    
-    @ApiModelProperty(value = "이메일 검증 토큰", example = "1231-24SDF-WER321123", required = true)
-    @NotBlank(message = "이메일 검증 토큰은 필수입니다.")
-    private String token;
+
+    @ApiModelProperty(value = "회원 아이디", example = "kakao_124125124124", required = true)
+    @NotBlank(message = "회원 아이디는 필수입니다.")
+    private String userId;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
@@ -22,9 +22,9 @@ public class MemberSignupRequest {
     @Pattern(regexp = "^[0-9]{8}@(inha.edu|inha.ac.kr)$", message = "인하대학교 이메일 형식만 가능합니다.")
     private String email;
 
-    @ApiModelProperty(value = "카카오 회원 번호", example = "123456789", required = true)
-    @NotNull(message = "카카오 회원 번호는 필수입니다.")
-    private Long kakaoId;
+    @ApiModelProperty(value = "카카오 인증 코드", example = "ASKDJASIN12231KNsakdasdl1210SSALadk5234", required = true)
+    @NotBlank(message = "카카오 인증 코드는 필수입니다.")
+    private String authorizationCode;
 
     @ApiModelProperty(value = "회원 실명", example = "홍길동", required = true)
     @NotBlank(message = "회원 실명은 필수입니다.")
@@ -45,4 +45,8 @@ public class MemberSignupRequest {
     @ApiModelProperty(value = "회원 학년", example = "FRESHMAN", required = true)
     @NotNull(message = "회원 학년은 필수입니다.")
     private MemberGrade grade;
+    
+    @ApiModelProperty(value = "이메일 검증 토큰", example = "1231-24SDF-WER321123", required = true)
+    @NotBlank(message = "이메일 검증 토큰은 필수입니다.")
+    private String token;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
@@ -22,10 +22,6 @@ public class MemberSignupRequest {
     @Pattern(regexp = "^[0-9]{8}@(inha.edu|inha.ac.kr)$", message = "인하대학교 이메일 형식만 가능합니다.")
     private String email;
 
-    @ApiModelProperty(value = "카카오 인증 코드", example = "ASKDJASIN12231KNsakdasdl1210SSALadk5234", required = true)
-    @NotBlank(message = "카카오 인증 코드는 필수입니다.")
-    private String authorizationCode;
-
     @ApiModelProperty(value = "회원 실명", example = "홍길동", required = true)
     @NotBlank(message = "회원 실명은 필수입니다.")
     private String name;

--- a/src/main/java/wegrus/clubwebsite/dto/member/ValidateEmailResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/ValidateEmailResponse.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-public class MemberSignupResponse {
+@AllArgsConstructor
+public class ValidateEmailResponse {
 
-    private MemberDto member;
+    private String status;
+    private String reason;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -14,10 +14,13 @@ public enum ResultCode {
     REISSUE_SUCCESS(200, "M103", "토큰 재발급에 성공하였습니다."),
     SIGNIN_FAILURE(200, "M104", "회원가입을 먼저 해주세요."),
     CHECK_EMAIL_SUCCESS(200, "M105", "이메일 검증에 성공하였습니다."),
-    VALID_EMAIL(200, "M106", "사용 가능한 이메일입니다."),
+    VALID_EMAIL(200, "M106", "사용 가능한 이메일입니다. 이메일에서 메일 인증을 완료해주세요."),
     GET_MEMBER_INFO_SUCCESS(200, "M107", "회원 정보 조회에 성공하였습니다."),
     UPDATE_MEMBER_INFO_SUCCESS(200, "M108", "회원 정보 수정에 성공하였습니다."),
     UPDATE_MEMBER_IMAGE_SUCCESS(200, "M109", "회원 이미지 변경에 성공하였습니다."),
+    VALIDATE_EMAIL_SUCCESS(200, "M110", "이메일 인증 여부 확인에 성공하였습니다."),
+    EMAIL_NOT_VERIFIED(200, "M111", "인증되지 않은 이메일입니다. 메일 인증을 먼저 해주세요."),
+    EMAIL_IS_VERIFIED(200, "M112", "인증된 이메일입니다. 회원가입을 계속 진행해 주세요."),
 
     // Board
     CREATE_BOARD_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -46,8 +46,8 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<CommentLike> commentLikes = new ArrayList<>();
 
-    @Column(name = "member_kakao_id", unique = true, nullable = false)
-    private Long kakaoId;
+    @Column(name = "member_user_id", unique = true, nullable = false)
+    private String userId;
 
     @Column(name = "member_email", unique = true, nullable = false)
     private String email;
@@ -93,8 +93,8 @@ public class Member {
     private MemberAcademicStatus academicStatus;
 
     @Builder
-    public Member(Long kakaoId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus) {
-        this.kakaoId = kakaoId;
+    public Member(String userId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus) {
+        this.userId = userId;
         this.email = email;
         this.name = name;
         this.studentId = email.substring(0, 8);

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
@@ -1,5 +1,5 @@
 package wegrus.clubwebsite.entity.member;
 
 public enum MemberRoles {
-    ROLE_GUEST, ROLE_CERTIFIED, ROLE_MEMBER, ROLE_ADMIN
+    ROLE_GUEST, ROLE_MEMBER, ROLE_ADMIN
 }

--- a/src/main/java/wegrus/clubwebsite/exception/EmailCertificationInvalidTokenException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/EmailCertificationInvalidTokenException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class EmailCertificationInvalidTokenException extends BusinessException {
+
+    public EmailCertificationInvalidTokenException() {
+        super(ErrorCode.EMAIL_CERTIFICATION_TOKEN_INVALID);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByKakaoIdOrEmail(Long kakaoId, String email);
+    Optional<Member> findByUserIdOrEmail(String userId, String email);
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByKakaoId(Long kakaoId);
+    Optional<Member> findByUserId(String userId);
 }

--- a/src/main/java/wegrus/clubwebsite/util/JwtTokenUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtTokenUtil.java
@@ -49,7 +49,6 @@ public class JwtTokenUtil {
         return Jwts.parser().setSigningKey(ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody();
     }
 
-
     private Claims getAllClaimsFromRefreshToken(String token) {
         return Jwts.parser().setSigningKey(REFRESH_TOKEN_SECRET).parseClaimsJws(token).getBody();
     }

--- a/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
@@ -1,0 +1,45 @@
+package wegrus.clubwebsite.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class KakaoUtil {
+
+    @Value("${oauth.kakao.rest-api-key}")
+    private String KAKAO_CLIENT_REST_API_KEY;
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public String getUserIdFromKakaoAPI(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, headers);
+        final ResponseEntity<Map> responseEntity = restTemplate.exchange("https://kapi.kakao.com/v2/user/me", HttpMethod.GET, requestEntity, Map.class);
+        final Map response = responseEntity.getBody();
+        return "kakao_" + response.get("id");
+    }
+
+    public String getAccessTokenFromKakaoAPI(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        final String url = "https://kauth.kakao.com/oauth/token";
+        final String grant_type = "authorization_code";
+        final String redirect_url = "http://localhost:3000/oauth/kakao/callback";
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, headers);
+        final ResponseEntity<Map> responseEntity = restTemplate.exchange(
+                url + "?grant_type=" + grant_type + "&client_id=" + KAKAO_CLIENT_REST_API_KEY + "&redirect_url=" + redirect_url + "&code=" + authorizationCode
+                , HttpMethod.POST, requestEntity, Map.class);
+        final Map response = responseEntity.getBody();
+        final String accessToken = (String) response.get("access_token");
+        return accessToken;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
   profiles:
     group:
-      local: local, aws
-      prod: prod, aws
+      local: local, aws, oauth
+      prod: prod, aws, oauth

--- a/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
@@ -42,7 +42,7 @@ public class BoardRepositoryTest {
                 .name("김철수")
                 .department("컴퓨터공학과")
                 .grade(MemberGrade.JUNIOR)
-                .kakaoId((long) 987654321)
+                .userId("21358921357")
                 .phone("010-1234-5678")
                 .email("test1@naver.com")
                 .academicStatus(MemberAcademicStatus.ATTENDING)

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -145,10 +145,10 @@ public class MemberControllerTest {
     void signup_success() throws Exception {
         // given
         final String verificationKey = UUID.randomUUID().toString();
-        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
         final MemberSignupResponse response = new MemberSignupResponse(new MemberDto(member), verificationKey);
         doReturn(response).when(memberService).validateAndSendVerificationMailAndSaveMember(any(MemberSignupRequest.class));
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", 123456789L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -168,9 +168,9 @@ public class MemberControllerTest {
     @DisplayName("회원 가입 API: 바인딩 예외")
     void signup_bindEx() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", 123456789L, "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
-        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", 123456789L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
-        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", 123456789L, "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR);
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", "123456789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -218,18 +218,18 @@ public class MemberControllerTest {
     @DisplayName("로그인 API: 성공")
     void login_success() throws Exception {
         // given
-        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
         final String accessToken = "accessToken";
         final String refreshToken = "refreshToken";
         final MemberAndJwtDto dto = new MemberAndJwtDto(new MemberDto(member), accessToken, refreshToken);
 
-        doReturn(dto).when(memberService).findMemberAndGenerateJwt(any(Long.class));
+        doReturn(dto).when(memberService).findMemberAndGenerateJwt(any(String.class));
 
         // when
         final ResultActions perform = mockMvc.perform(
                 post("/signin").with(csrf())
                         .contentType(APPLICATION_FORM_URLENCODED)
-                        .param("kakaoId", "123456789")
+                        .param("authorizationCode", "123456789L")
         );
 
         // then
@@ -248,13 +248,13 @@ public class MemberControllerTest {
     @DisplayName("로그인 API: 실패")
     void login_fail() throws Exception {
         // given
-        doThrow(MemberNotFoundException.class).when(memberService).findMemberAndGenerateJwt(any(Long.class));
+        doThrow(MemberNotFoundException.class).when(memberService).findMemberAndGenerateJwt(any(String.class));
 
         // when
         final ResultActions perform = mockMvc.perform(
                 post("/signin").with(csrf())
                         .contentType(APPLICATION_FORM_URLENCODED)
-                        .param("kakaoId", "123456789")
+                        .param("authorizationCode", "123456789")
         );
 
         // then
@@ -269,13 +269,13 @@ public class MemberControllerTest {
     @DisplayName("로그인 API: 바인딩 예외")
     void login_bindEx() throws Exception {
         // given
-        final Long kakaoId = null;
+        final String authorizationCode = "";
 
         // when
         final ResultActions perform = mockMvc.perform(
                 post("/signin").with(csrf())
                         .contentType(APPLICATION_FORM_URLENCODED)
-                        .param("kakaoId", String.valueOf(kakaoId))
+                        .param("authorizationCode", authorizationCode)
         );
 
         // then
@@ -403,7 +403,7 @@ public class MemberControllerTest {
     @DisplayName("회원 정보 조회 API: 성공")
     void getInfo_success() throws Exception {
         // given
-        final Member member = new Member(123456789L, "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
         final MemberInfoResponse response = new MemberInfoResponse(Status.SUCCESS, new MemberDto(member));
         final MemberInfoResponse response2 = new MemberInfoResponse(Status.SUCCESS, new MemberSimpleDto(member));
         doReturn(response).when(memberService).getMemberInfo(1L);

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -29,6 +29,7 @@ import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.service.MemberService;
+import wegrus.clubwebsite.util.RedisUtil;
 
 import javax.servlet.http.Cookie;
 import java.io.FileInputStream;
@@ -59,6 +60,9 @@ public class MemberControllerTest {
 
     @MockBean
     private MemberService memberService;
+
+    @MockBean
+    private RedisUtil redisUtil;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -144,11 +148,10 @@ public class MemberControllerTest {
     @DisplayName("회원 가입 API: 성공")
     void signup_success() throws Exception {
         // given
-        final String verificationKey = UUID.randomUUID().toString();
         final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
-        final MemberSignupResponse response = new MemberSignupResponse(new MemberDto(member), verificationKey);
-        doReturn(response).when(memberService).validateAndSendVerificationMailAndSaveMember(any(MemberSignupRequest.class));
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupResponse response = new MemberSignupResponse(new MemberDto(member));
+        doReturn(response).when(memberService).validateAndSaveMember(any(MemberSignupRequest.class));
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L");
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -160,17 +163,16 @@ public class MemberControllerTest {
         // then
         perform
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("code").value(SIGNUP_SUCCESS.getCode()))
-                .andExpect(jsonPath("data.verificationKey").value(verificationKey));
+                .andExpect(jsonPath("code").value(SIGNUP_SUCCESS.getCode()));
     }
 
     @Test
     @DisplayName("회원 가입 API: 바인딩 예외")
     void signup_bindEx() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
-        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", "123456789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
-        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", "123456789L", "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -249,6 +251,8 @@ public class MemberControllerTest {
     void login_fail() throws Exception {
         // given
         doThrow(MemberNotFoundException.class).when(memberService).findMemberAndGenerateJwt(any(String.class));
+        doReturn("userId").when(redisUtil).get(any(String.class));
+        doReturn(true).when(redisUtil).delete(any(String.class));
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -342,7 +346,7 @@ public class MemberControllerTest {
         final String email = "12161111@inha.edu";
         final EmailCheckResponse response = new EmailCheckResponse(Status.SUCCESS, VALID_EMAIL.getMessage());
 
-        doReturn(response).when(memberService).checkEmail(any(String.class));
+        doReturn(response).when(memberService).checkEmailAndSendMail(any(String.class));
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -369,8 +373,8 @@ public class MemberControllerTest {
         final EmailCheckResponse response = new EmailCheckResponse(Status.FAILURE, EMAIL_ALREADY_EXIST.getMessage());
         final EmailCheckResponse response2 = new EmailCheckResponse(Status.FAILURE, INVALID_EMAIL.getMessage());
 
-        doReturn(response).when(memberService).checkEmail(email);
-        doReturn(response2).when(memberService).checkEmail(invalidEmail);
+        doReturn(response).when(memberService).checkEmailAndSendMail(email);
+        doReturn(response2).when(memberService).checkEmailAndSendMail(invalidEmail);
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -499,5 +503,51 @@ public class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("code").value(UPDATE_MEMBER_IMAGE_SUCCESS.getCode()))
                 .andExpect(jsonPath("message").value(UPDATE_MEMBER_IMAGE_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 여부 확인 API: 성공")
+    void validateEmail_success() throws Exception {
+        // given
+        final ValidateEmailResponse validateEmailResponse = new ValidateEmailResponse(Status.SUCCESS, EMAIL_IS_VERIFIED.getMessage());
+        doReturn(validateEmailResponse).when(memberService).validateEmail(any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                get("/signup/validate/email").with(csrf())
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("email", "12161542@inha.edu")
+        );
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(VALIDATE_EMAIL_SUCCESS.getCode()))
+                .andExpect(jsonPath("message").value(VALIDATE_EMAIL_SUCCESS.getMessage()))
+                .andExpect(jsonPath("data.status").value(Status.SUCCESS))
+                .andExpect(jsonPath("data.reason").value(EMAIL_IS_VERIFIED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 여부 확인 API: 실패")
+    void validateEmail_fail() throws Exception {
+        // given
+        final ValidateEmailResponse validateEmailResponse = new ValidateEmailResponse(Status.FAILURE, EMAIL_NOT_VERIFIED.getMessage());
+        doReturn(validateEmailResponse).when(memberService).validateEmail(any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                get("/signup/validate/email").with(csrf())
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("email", "12161542@inha.edu")
+        );
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(VALIDATE_EMAIL_SUCCESS.getCode()))
+                .andExpect(jsonPath("message").value(VALIDATE_EMAIL_SUCCESS.getMessage()))
+                .andExpect(jsonPath("data.status").value(Status.FAILURE))
+                .andExpect(jsonPath("data.reason").value(EMAIL_NOT_VERIFIED.getMessage()));
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -1,15 +1,20 @@
 package wegrus.clubwebsite.member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
@@ -17,9 +22,18 @@ import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
 import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.util.AmazonS3Util;
+import wegrus.clubwebsite.util.KakaoUtil;
 import wegrus.clubwebsite.util.RedisUtil;
+import wegrus.clubwebsite.vo.Image;
+
+import java.io.*;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static wegrus.clubwebsite.dto.result.ResultCode.VERIFY_EMAIL_SUCCESS;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -35,6 +49,20 @@ public class MemberIntegrationTest {
     @Autowired
     private RedisUtil redisUtil;
 
+    @MockBean
+    private KakaoUtil kakaoUtil;
+
+    @MockBean
+    private AmazonS3Util amazonS3Util;
+
+    @BeforeEach
+    void init() throws IOException {
+        doReturn(UUID.randomUUID().toString()).when(kakaoUtil).getUserIdFromKakaoAPI(any(String.class));
+        doReturn(UUID.randomUUID().toString()).when(kakaoUtil).getAccessTokenFromKakaoAPI(any(String.class));
+        doNothing().when(amazonS3Util).deleteImage(any(Image.class), any(String.class));
+        doReturn(Image.builder().url("new url").build()).when(amazonS3Util).uploadImage(any(MultipartFile.class), any(String.class));
+    }
+
     public EmailCheckResponse checkEmailAPI(String email) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -47,8 +75,8 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(response.getBody().getData(), EmailCheckResponse.class);
     }
 
-    public MemberSignupResponse signupAPI(String email, Long kakaoId, String name, String department, String phone, MemberAcademicStatus memberAcademicStatus, MemberGrade memberGrade) {
-        final MemberSignupRequest memberSignupRequest = new MemberSignupRequest(email, kakaoId, name, department, phone, memberAcademicStatus, memberGrade);
+    public MemberSignupResponse signupAPI(String email, String userId, String name, String department, String phone, MemberAcademicStatus memberAcademicStatus, MemberGrade memberGrade, String token) {
+        final MemberSignupRequest memberSignupRequest = new MemberSignupRequest(email, userId, name, department, phone, memberAcademicStatus, memberGrade, token);
 
         final HttpEntity<MemberSignupRequest> request = new HttpEntity<>(memberSignupRequest);
         final ResponseEntity<ResultResponse> response = restTemplate.postForEntity("/signup", request, ResultResponse.class);
@@ -68,13 +96,13 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(response.getBody().getData(), VerificationResponse.class);
     }
 
-    public ResponseEntity<ResultResponse> signinAPI(Long kakaoId) {
+    public ResponseEntity<ResultResponse> signinAPI(String authorizationCode) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        MultiValueMap<String, Long> map = new LinkedMultiValueMap<>();
-        map.add("kakaoId", kakaoId);
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("authorizationCode", authorizationCode);
 
-        final HttpEntity<MultiValueMap<String, Long>> request = new HttpEntity<>(map, headers);
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
         return restTemplate.exchange("/signin", HttpMethod.POST, request, ResultResponse.class);
     }
 
@@ -113,6 +141,19 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(responseEntity.getBody().getData(), MemberInfoUpdateResponse.class);
     }
 
+    public MemberImageUpdateResponse updateImageAPI(String accessToken, Resource resource) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", resource);
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        final ResponseEntity<ResultResponse> responseEntity = restTemplate.exchange("/members/image", HttpMethod.PATCH, requestEntity, ResultResponse.class);
+        return objectMapper.convertValue(responseEntity.getBody().getData(), MemberImageUpdateResponse.class);
+    }
+
     @Test
     @DisplayName("이메일 검증")
     void checkEmail() throws Exception {
@@ -131,10 +172,11 @@ public class MemberIntegrationTest {
     void signup() throws Exception {
         // given
         final String email = "12345679@inha.edu";
-        checkEmailAPI(email);
-        
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+
         // when
-        final MemberSignupResponse response = signupAPI(email, 123433789L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final MemberSignupResponse response = signupAPI(email, "123433789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = response.getVerificationKey();
         redisUtil.delete(verificationKey);
 
@@ -147,8 +189,9 @@ public class MemberIntegrationTest {
     void verifyEmail() throws Exception {
         // given
         final String email = "12161542@inha.edu";
-        checkEmailAPI(email);
-        final MemberSignupResponse memberSignupResponse = signupAPI(email, 123456789L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, "123456789L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
 
         // when
@@ -164,14 +207,15 @@ public class MemberIntegrationTest {
     void signin() throws Exception {
         // given
         final String email = "12344279@inha.edu";
-        final long kakaoId = 111456789L;
-        checkEmailAPI(email);
-        final MemberSignupResponse memberSignupResponse = signupAPI(email, kakaoId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String userId = "111456789L";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, userId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
         verifySchoolEmailAPI(verificationKey);
 
         // when
-        final ResponseEntity<ResultResponse> responseEntity = signinAPI(kakaoId);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI(userId);
         final MemberSigninSuccessResponse response = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
 
         // then
@@ -187,12 +231,13 @@ public class MemberIntegrationTest {
     void signout() throws Exception {
         // given
         final String email = "12845679@inha.edu";
-        final long kakaoId = 123477789L;
-        checkEmailAPI(email);
-        final MemberSignupResponse memberSignupResponse = signupAPI(email, kakaoId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String userId = "123477789L";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, userId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
         verifySchoolEmailAPI(verificationKey);
-        final ResponseEntity<ResultResponse> resultResponseResponseEntity = signinAPI(kakaoId);
+        final ResponseEntity<ResultResponse> resultResponseResponseEntity = signinAPI(userId);
         final String cookie = resultResponseResponseEntity.getHeaders().get("Set-Cookie").get(0);
         final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(resultResponseResponseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
         final String accessToken = memberSigninSuccessResponse.getAccessToken();
@@ -212,14 +257,15 @@ public class MemberIntegrationTest {
     void reissue() throws Exception {
         // given
         final String email = "44345679@inha.edu";
-        final long kakaoId = 123455789L;
-        checkEmailAPI(email);
-        final MemberSignupResponse memberSignupResponse = signupAPI(email, kakaoId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String userId = "123455789L";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, userId, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
         verifySchoolEmailAPI(verificationKey);
-        final ResponseEntity<ResultResponse> resultResponseResponseEntity = signinAPI(kakaoId);
+        final ResponseEntity<ResultResponse> resultResponseResponseEntity = signinAPI(userId);
         final String cookie = resultResponseResponseEntity.getHeaders().get("Set-Cookie").get(0);
-        
+
         // when
         final ResponseEntity<ResultResponse> responseEntity = reissueAPI(cookie);
         final ReIssueResponse response = objectMapper.convertValue(responseEntity.getBody().getData(), ReIssueResponse.class);
@@ -236,18 +282,24 @@ public class MemberIntegrationTest {
     @DisplayName("회원 정보 조회")
     void getInfo() throws Exception {
         // given
-        checkEmailAPI("12344379@inha.edu");
-        final MemberSignupResponse memberSignupResponse = signupAPI("12344379@inha.edu", 111456389L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String email = "12344379@inha.edu";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, "111456389L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
         verifySchoolEmailAPI(verificationKey);
-        final ResponseEntity<ResultResponse> responseEntity = signinAPI(111456389L);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI("111456389L");
         final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
         final String accessToken = memberSigninSuccessResponse.getAccessToken();
 
-        final MemberSignupResponse memberSignupResponse2 = signupAPI("12444379@inha.edu", 111222389L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        doReturn(UUID.randomUUID().toString()).when(kakaoUtil).getUserIdFromKakaoAPI(any(String.class));
+        final String email2 = "12499300@inha.edu";
+        final EmailCheckResponse emailCheckResponse2 = checkEmailAPI(email2);
+        final String token2 = emailCheckResponse2.getToken();
+        final MemberSignupResponse memberSignupResponse2 = signupAPI(email2, "15523222389L", "홍길동2", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token2);
         final String verificationKey2 = memberSignupResponse2.getVerificationKey();
         verifySchoolEmailAPI(verificationKey2);
-        final ResponseEntity<ResultResponse> responseEntity2 = signinAPI(111222389L);
+        final ResponseEntity<ResultResponse> responseEntity2 = signinAPI("111222389L");
         final MemberSigninSuccessResponse memberSigninSuccessResponse2 = objectMapper.convertValue(responseEntity2.getBody().getData(), MemberSigninSuccessResponse.class);
 
         // when
@@ -259,17 +311,20 @@ public class MemberIntegrationTest {
 
         // then
         assertThat(info.getStudentId()).isEqualTo("12344379");
-        assertThat(info2.getStudentId()).isEqualTo("44");
+        assertThat(info2.getStudentId()).isEqualTo("49");
     }
-    
+
     @Test
     @DisplayName("회원 정보 수정")
     void updateInfo() throws Exception {
         // given
-        final MemberSignupResponse memberSignupResponse = signupAPI("24344311@inha.edu", 151456339L, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN);
+        final String email = "24344311@inha.edu";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, "151456339L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
         final String verificationKey = memberSignupResponse.getVerificationKey();
         verifySchoolEmailAPI(verificationKey);
-        final ResponseEntity<ResultResponse> responseEntity = signinAPI(151456339L);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI("151456339L");
         final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
         final String accessToken = memberSigninSuccessResponse.getAccessToken();
         final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-1234-1234", MemberAcademicStatus.ABSENCE, MemberGrade.FRESHMAN, "안녕");
@@ -282,5 +337,28 @@ public class MemberIntegrationTest {
         assertThat(response.getDepartment()).isEqualTo("정통");
         assertThat(response.getAcademicStatus()).isEqualTo(MemberAcademicStatus.ABSENCE);
         assertThat(response.getIntroduce()).isEqualTo("안녕");
+    }
+
+    @Test
+    @DisplayName("회원 이미지 변경")
+    void updateImage() throws Exception {
+        // given
+        final String email = "24999911@inha.edu";
+        final EmailCheckResponse emailCheckResponse = checkEmailAPI(email);
+        final String token = emailCheckResponse.getToken();
+        final MemberSignupResponse memberSignupResponse = signupAPI(email, "15222339L", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, token);
+        final String verificationKey = memberSignupResponse.getVerificationKey();
+        verifySchoolEmailAPI(verificationKey);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI("151456339L");
+        final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
+        final String accessToken = memberSigninSuccessResponse.getAccessToken();
+        final Resource resource = new FileSystemResource("src/test/resources/static/image.jpg");
+
+        // when
+        final MemberImageUpdateResponse response = updateImageAPI(accessToken, resource);
+
+        // then
+        assertThat(response.getImageUrl()).isEqualTo("new url");
+        assertThat(response.getStatus()).isEqualTo(Status.SUCCESS);
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
@@ -37,37 +37,37 @@ public class MemberRepositoryTest {
     }
 
     @Test
-    @DisplayName("회원 조회: 카카오 회원 번호 or 이메일")
-    void findByKakaoIdOrEmail() throws Exception {
+    @DisplayName("회원 조회: userId or email")
+    void findByUserIdOrEmail() throws Exception {
         // given
-        final String realUserId = "1234568L";
+        final String realUserId = "12345672";
         final String fakeEmail = "에베베";
         final String fakeUserId = "1L";
-        final String realEmail = "12161541@inha.edu";
+        final String realEmail = "12161542@inha.edu";
 
         // when
-        final Member findMemberByKakaoId = memberRepository.findByUserIdOrEmail(realUserId, fakeEmail).orElseThrow(MemberNotFoundException::new);
+        final Member findMemberByUserId = memberRepository.findByUserIdOrEmail(realUserId, fakeEmail).orElseThrow(MemberNotFoundException::new);
         final Member findMemberByEmail = memberRepository.findByUserIdOrEmail(fakeUserId, realEmail).orElseThrow(MemberNotFoundException::new);
 
         // then
-        assertThat(findMemberByEmail).isEqualTo(findMemberByKakaoId);
+        assertThat(findMemberByEmail).isEqualTo(findMemberByUserId);
     }
 
     @Test
-    @DisplayName("회원 조회: 카카오 회원 번호")
-    void findByKakaoId() throws Exception {
+    @DisplayName("회원 조회: userId")
+    void findByUserId() throws Exception {
         // given
-        final String userId = "1234568L";
+        final String userId = "12345671";
 
         // when
-        final Member findMemberByKakaoId = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
+        final Member findMemberByUserId = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
 
         // then
-        assertThat(findMemberByKakaoId.getUserId()).isEqualTo(userId);
+        assertThat(findMemberByUserId.getUserId()).isEqualTo(userId);
     }
 
     @Test
-    @DisplayName("회원 조회: 이메일")
+    @DisplayName("회원 조회: email")
     void findByEmail() throws Exception {
         // given
         final String email = "12161541@inha.edu";

--- a/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
@@ -28,7 +28,7 @@ public class MemberRepositoryTest {
                     .department("컴퓨터공학과")
                     .academicStatus(i % 2 == 1 ? MemberAcademicStatus.ATTENDING : MemberAcademicStatus.ABSENCE)
                     .phone("010-1234-567" + i)
-                    .kakaoId((long) (1234567 + i))
+                    .userId("1234567" + i)
                     .grade(MemberGrade.FRESHMAN)
                     .build();
 
@@ -40,14 +40,14 @@ public class MemberRepositoryTest {
     @DisplayName("회원 조회: 카카오 회원 번호 or 이메일")
     void findByKakaoIdOrEmail() throws Exception {
         // given
-        final long realKakaoId = 1234568L;
+        final String realUserId = "1234568L";
         final String fakeEmail = "에베베";
-        final long fakeKakaoId = 1L;
+        final String fakeUserId = "1L";
         final String realEmail = "12161541@inha.edu";
 
         // when
-        final Member findMemberByKakaoId = memberRepository.findByKakaoIdOrEmail(realKakaoId, fakeEmail).orElseThrow(MemberNotFoundException::new);
-        final Member findMemberByEmail = memberRepository.findByKakaoIdOrEmail(fakeKakaoId, realEmail).orElseThrow(MemberNotFoundException::new);
+        final Member findMemberByKakaoId = memberRepository.findByUserIdOrEmail(realUserId, fakeEmail).orElseThrow(MemberNotFoundException::new);
+        final Member findMemberByEmail = memberRepository.findByUserIdOrEmail(fakeUserId, realEmail).orElseThrow(MemberNotFoundException::new);
 
         // then
         assertThat(findMemberByEmail).isEqualTo(findMemberByKakaoId);
@@ -57,13 +57,13 @@ public class MemberRepositoryTest {
     @DisplayName("회원 조회: 카카오 회원 번호")
     void findByKakaoId() throws Exception {
         // given
-        final long kakaoId = 1234568L;
+        final String userId = "1234568L";
 
         // when
-        final Member findMemberByKakaoId = memberRepository.findByKakaoId(kakaoId).orElseThrow(MemberNotFoundException::new);
+        final Member findMemberByKakaoId = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
 
         // then
-        assertThat(findMemberByKakaoId.getKakaoId()).isEqualTo(kakaoId);
+        assertThat(findMemberByKakaoId.getUserId()).isEqualTo(userId);
     }
 
     @Test


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #28 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 엔티티 kakaoId 필드 네이밍 변경 
- 추후에 다른 소셜 로그인 방식 추가도 고려하여 `userId`로 변경하였습니다.
- 예를 들어, 카카오 로그인인 경우에는 `kakao_카카오 회원 번호`를 userId로 저장합니다.

### 로그인 API, 회원가입 API
- 카카오 인증 코드를 받고, 서버에서 Kakao REST API를 호출하여 회원 정보를 받아오는 방식으로 변경
- 로그인 실패 시, 카카오 회원 번호를 조합한 `userId`를 응답 -> 회원가입 때 사용
- 프론트단에서 카카오 로그인 API 호출 후 응답으로 받은 카카오 인증 코드를 서버로 전달, 서버에서 해당 인증 코드를 이용하여 Kakao REST API를 호출, 회원 정보를 받아와서 새로 AccessToken, RefreshToken 발급
    - 해당 인증 코드는 한 번 사용하면 재사용이 불가능하므로, 각 API마다 인증 코드를 따로 받습니다.
    - 인증 코드 재사용 시 발생하는 에러
    ![image](https://user-images.githubusercontent.com/68049320/150657140-1edbcaca-15cc-4f66-8baf-5e3b0ff81cf8.png)
    - Kakao REST-API-Key는 프론트단에서 발급받은 키를 사용하였고, Redirect-url도 동일하게 설정하였습니다.
        - Redirect-url이 다르면 에러가 발생합니다.
- 카카오 API 호출로 받은 JWT를 그대로 사용하면, 개인 정보가 유출되므로 서버에서 새로 JWT를 발급해주었습니다.
- Kakao REST API 호출하는 메소드를 모아둔 `KakaoUtil` 클래스를 추가하였습니다.

### 이메일 검증 API, 이메일 인증 API, 이메일 인증 여부 확인 API
- 이메일 검증 성공 시, 본인 이메일 인증 메일 전송
- 해당 메일에서 [메일 인증] 버튼 클릭 시, 이메일 인증 API 호출 -> 해당 이메일을 30분간 가입 가능 상태로 Redis에 저장
- 이메일 인증 여부 확인 API를 통해 Redis에 해당 이메일이 있는지 확인 -> 성공 시, 회원가입 폼으로 리다이렉트

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- 카카오 로그인 부분을 테스트 코드로 작성하기 어려워서 프론트 분들 코드를 clone받아서 테스트 했습니다.
- 카카오 인증 코드만 받고, 나머지는 Swagger, Postman으로 테스트 성공했습니다.
- 테스트 코드는 KakaoUtil, AmazonS3Util를 mocking하여 진행하였습니다.

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- [JWT를 이용한 소셜 로그인 구현](https://earth-95.tistory.com/105)
- [Kakao Developers 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code)
- [Rest API 활용한 카카오 소셜 로그인 구현(feat. React)](https://data-jj.tistory.com/53)
- [Kakao Rest API "Redirect URI mismatch" 에러 처리](https://gogomalibu.tistory.com/142)

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
