### PR TITLE
회원 권한 요청 API 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -15,6 +15,7 @@ import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.service.MemberService;
 import wegrus.clubwebsite.util.RedisUtil;
@@ -167,5 +168,13 @@ public class MemberController {
         final ValidateEmailResponse response = memberService.validateEmail(email);
 
         return ResponseEntity.ok(ResultResponse.of(VALIDATE_EMAIL_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 권한 요청")
+    @PostMapping("/members/authority")
+    public ResponseEntity<ResultResponse> requestAuthority(@NotNull(message = "요청할 권한은 필수입니다.") @RequestParam(name = "role") MemberRoles role) {
+        final RequestAuthorityResponse response = memberService.requestAuthority(role);
+
+        return ResponseEntity.ok(ResultResponse.of(REQUEST_AUTHORITY_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     MEMBER_ROLE_NOT_FOUND(400, "M004", "존재하지 않는 회원 등급입니다."),
     MEMBER_IMAGE_ALREADY_BASIC(400, "M005", "회원 이미지가 이미 기본 이미지입니다."),
     EMAIL_CERTIFICATION_TOKEN_INVALID(400, "M006", "이메일 검증 토큰이 유효하지 않습니다."),
+    MEMBER_ALREADY_HAS_ROLE(400, "M007", "이미 해당 권한을 가지고 있는 회원입니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityResponse.java
@@ -1,0 +1,15 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.MemberRoles;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestAuthorityResponse {
+
+    private String status;
+    private MemberRoles role;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -21,6 +21,7 @@ public enum ResultCode {
     VALIDATE_EMAIL_SUCCESS(200, "M110", "이메일 인증 여부 확인에 성공하였습니다."),
     EMAIL_NOT_VERIFIED(200, "M111", "인증되지 않은 이메일입니다. 메일 인증을 먼저 해주세요."),
     EMAIL_IS_VERIFIED(200, "M112", "인증된 이메일입니다. 회원가입을 계속 진행해 주세요."),
+    REQUEST_AUTHORITY_SUCCESS(200, "M113", "권한 요청에 성공하였습니다."),
 
     // Board
     CREATE_BOARD_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/Request.java
+++ b/src/main/java/wegrus/clubwebsite/entity/Request.java
@@ -1,0 +1,44 @@
+package wegrus.clubwebsite.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.member.Role;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "requests")
+public class Request {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "request_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+    @CreatedDate
+    @Column(name = "request_created_date", nullable = false)
+    private LocalDateTime createdDate;
+
+    @Builder
+    public Request(Member member, Role role) {
+        this.member = member;
+        this.role = role;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyHasRoleException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyHasRoleException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class MemberAlreadyHasRoleException extends BusinessException {
+
+    public MemberAlreadyHasRoleException() {
+        super(ErrorCode.MEMBER_ALREADY_HAS_ROLE);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
@@ -3,5 +3,8 @@ package wegrus.clubwebsite.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.member.MemberRole;
 
+import java.util.Optional;
+
 public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+    Optional<MemberRole> findByMemberIdAndRoleId(Long memberId, Long roleId);
 }

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -192,4 +192,16 @@ public class MemberService {
         redisUtil.delete(email);
         return new ValidateEmailResponse(Status.SUCCESS, EMAIL_IS_VERIFIED.getMessage());
     }
+
+    @Transactional
+    public RequestAuthorityResponse requestAuthority(MemberRoles memberRoles) {
+        final Role role = roleRepository.findByName(memberRoles.name()).orElseThrow(MemberRoleNotFoundException::new);
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        if (memberRoleRepository.findByMemberIdAndRoleId(memberId, role.getId()).isPresent())
+            throw new MemberAlreadyHasRoleException();
+        memberRoleRepository.save(new MemberRole(member, role));
+        return new RequestAuthorityResponse(Status.SUCCESS, memberRoles);
+    }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -27,6 +27,7 @@ import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
+import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.service.MemberService;
 import wegrus.clubwebsite.util.RedisUtil;
@@ -549,5 +550,27 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("message").value(VALIDATE_EMAIL_SUCCESS.getMessage()))
                 .andExpect(jsonPath("data.status").value(Status.FAILURE))
                 .andExpect(jsonPath("data.reason").value(EMAIL_NOT_VERIFIED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("회원 권한 요청 API: 성공")
+    void requestAuthority_success() throws Exception {
+        // given
+        final RequestAuthorityResponse requestAuthorityResponse = new RequestAuthorityResponse(Status.SUCCESS, MemberRoles.ROLE_MEMBER);
+        doReturn(requestAuthorityResponse).when(memberService).requestAuthority(any(MemberRoles.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                post("/members/authority").with(csrf())
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("role", MemberRoles.ROLE_MEMBER.name())
+        );
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(REQUEST_AUTHORITY_SUCCESS.getCode()))
+                .andExpect(jsonPath("message").value(REQUEST_AUTHORITY_SUCCESS.getMessage()))
+                .andExpect(jsonPath("data.role").value(MemberRoles.ROLE_MEMBER.name()));
     }
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #31 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

- MemberRoles에 존재하는 권한을 요청할 수 있습니다.
    - 이미 존재하는 권한은 요청할 수 없습니다 -> 400 응답
    - 이 API를 이용하여 동아리원 가입 신청, 소모임 가입 신청 등 권한이 필요한 곳에서 공용으로 사용 가능합니다.
- Request 엔티티 추가하였습니다.
    - 추후 어드민은 각 권한에 대한 요청 목록을 이 엔티티를 통해 조회가 가능합니다.

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
