### PR TITLE
회원 탈퇴 API, 회원 재가입 로직 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -2,23 +2,45 @@ package wegrus.clubwebsite.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import wegrus.clubwebsite.entity.member.MemberRoles;
-import wegrus.clubwebsite.entity.member.Role;
 import wegrus.clubwebsite.repository.RoleRepository;
 
 import javax.annotation.PostConstruct;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Configuration
 @RequiredArgsConstructor
 public class SetupConfig {
 
     private final RoleRepository roleRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @PostConstruct
     private void setup() {
-        if (roleRepository.findAll().isEmpty()) {
-            for (MemberRoles role : MemberRoles.values())
-                roleRepository.save(new Role(role.name()));
-        }
+        roleRepository.deleteAllInBatch();
+
+        final List<String> roles = Arrays.stream(MemberRoles.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String sql = "INSERT INTO ROLES (`role_name`) VALUES(?)";
+        final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, roles.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return roles.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(sql, pss);
     }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -17,6 +17,8 @@ import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.exception.MemberAlreadyBanException;
+import wegrus.clubwebsite.exception.MemberAlreadyResignException;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.service.MemberService;
 import wegrus.clubwebsite.util.RedisUtil;
@@ -81,7 +83,19 @@ public class MemberController {
             final MemberSigninFailResponse response = new MemberSigninFailResponse(Status.FAILURE, userId);
             redisUtil.delete(authorizationCode);
 
-            return ResponseEntity.ok(ResultResponse.of(SIGNIN_FAILURE, response));
+            return ResponseEntity.ok(ResultResponse.of(NEED_TO_SIGNUP, response));
+        } catch (MemberAlreadyResignException e) {
+            final String userId = (String) redisUtil.get(authorizationCode);
+            final MemberSigninFailResponse response = new MemberSigninFailResponse(Status.FAILURE, userId);
+            redisUtil.delete(authorizationCode);
+
+            return ResponseEntity.ok(ResultResponse.of(NEED_TO_REJOIN, response));
+        } catch (MemberAlreadyBanException e) {
+            final String userId = (String) redisUtil.get(authorizationCode);
+            final MemberSigninFailResponse response = new MemberSigninFailResponse(Status.FAILURE, userId);
+            redisUtil.delete(authorizationCode);
+
+            return ResponseEntity.ok(ResultResponse.of(BANNED_USER, response));
         }
     }
 

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
+import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
@@ -176,5 +177,13 @@ public class MemberController {
         final RequestAuthorityResponse response = memberService.requestAuthority(role);
 
         return ResponseEntity.ok(ResultResponse.of(REQUEST_AUTHORITY_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 탈퇴")
+    @PostMapping("/members/resign")
+    public ResponseEntity<ResultResponse> resign() {
+        final StatusResponse response = memberService.resign();
+
+        return ResponseEntity.ok(ResultResponse.of(MEMBER_RESIGN_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/StatusResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/StatusResponse.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StatusResponse {
+
+    private String status;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -40,6 +40,11 @@ public enum ErrorCode {
     MEMBER_IMAGE_ALREADY_BASIC(400, "M005", "회원 이미지가 이미 기본 이미지입니다."),
     EMAIL_CERTIFICATION_TOKEN_INVALID(400, "M006", "이메일 검증 토큰이 유효하지 않습니다."),
     MEMBER_ALREADY_HAS_ROLE(400, "M007", "이미 해당 권한을 가지고 있는 회원입니다."),
+    MEMBER_CANNOT_RESIGN(400, "M008", "탈퇴를 할 수 없는 회원입니다."),
+    CLUB_PRESIDENT_CANNOT_RESIGN(400, "M009", "동아리 회장은 회원 탈퇴를 할 수 없습니다."),
+    RESIGNED_MEMBER_CANNOT_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
+    BANNED_MEMBER_CANNOT_RESIGN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
+
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -42,9 +42,8 @@ public enum ErrorCode {
     MEMBER_ALREADY_HAS_ROLE(400, "M007", "이미 해당 권한을 가지고 있는 회원입니다."),
     MEMBER_CANNOT_RESIGN(400, "M008", "탈퇴를 할 수 없는 회원입니다."),
     CLUB_PRESIDENT_CANNOT_RESIGN(400, "M009", "동아리 회장은 회원 탈퇴를 할 수 없습니다."),
-    RESIGNED_MEMBER_CANNOT_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
-    BANNED_MEMBER_CANNOT_RESIGN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
-
+    MEMBER_ALREADY_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
+    MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -22,6 +22,7 @@ public enum ResultCode {
     EMAIL_NOT_VERIFIED(200, "M111", "인증되지 않은 이메일입니다. 메일 인증을 먼저 해주세요."),
     EMAIL_IS_VERIFIED(200, "M112", "인증된 이메일입니다. 회원가입을 계속 진행해 주세요."),
     REQUEST_AUTHORITY_SUCCESS(200, "M113", "권한 요청에 성공하였습니다."),
+    MEMBER_RESIGN_SUCCESS(200, "M114", "회원 탈퇴에 성공하였습니다."),
 
     // Board
     CREATE_BOARD_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -12,7 +12,7 @@ public enum ResultCode {
     SIGNIN_SUCCESS(200, "M101", "로그인에 성공하였습니다."),
     SIGNOUT_SUCCESS(200, "M102", "로그아웃에 성공하였습니다."),
     REISSUE_SUCCESS(200, "M103", "토큰 재발급에 성공하였습니다."),
-    SIGNIN_FAILURE(200, "M104", "회원가입을 먼저 해주세요."),
+    NEED_TO_SIGNUP(200, "M104", "회원가입을 먼저 해주세요."),
     CHECK_EMAIL_SUCCESS(200, "M105", "이메일 검증에 성공하였습니다."),
     VALID_EMAIL(200, "M106", "사용 가능한 이메일입니다. 이메일에서 메일 인증을 완료해주세요."),
     GET_MEMBER_INFO_SUCCESS(200, "M107", "회원 정보 조회에 성공하였습니다."),
@@ -23,6 +23,8 @@ public enum ResultCode {
     EMAIL_IS_VERIFIED(200, "M112", "인증된 이메일입니다. 회원가입을 계속 진행해 주세요."),
     REQUEST_AUTHORITY_SUCCESS(200, "M113", "권한 요청에 성공하였습니다."),
     MEMBER_RESIGN_SUCCESS(200, "M114", "회원 탈퇴에 성공하였습니다."),
+    NEED_TO_REJOIN(200, "M115", "탈퇴한 회원입니다. 회원 가입을 먼저 해주세요."),
+    BANNED_USER(200, "M116", "강제 탈퇴된 회원입니다."),
 
     // Board
     CREATE_BOARD_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -117,4 +117,16 @@ public class Member {
     public void updateImage(Image image) {
         this.image = image;
     }
+
+    public void resign() {
+        this.academicStatus = MemberAcademicStatus.ETC;
+        this.grade = MemberGrade.ETC;
+        this.phone = "";
+        this.introduce = "";
+        this.department = "";
+        this.email = "";
+        this.name = "";
+        this.studentId = "";
+        this.image = Image.builder().url(MEMBER_BASIC_IMAGE_URL).build();
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import wegrus.clubwebsite.dto.member.MemberInfoUpdateRequest;
+import wegrus.clubwebsite.dto.member.MemberSignupRequest;
 import wegrus.clubwebsite.entity.board.Board;
 import wegrus.clubwebsite.entity.board.CommentLike;
 import wegrus.clubwebsite.entity.board.PostLike;
@@ -128,5 +129,15 @@ public class Member {
         this.name = "";
         this.studentId = "";
         this.image = Image.builder().url(MEMBER_BASIC_IMAGE_URL).build();
+    }
+
+    public void rejoin(MemberSignupRequest request) {
+        this.email = request.getEmail();
+        this.studentId = request.getEmail().substring(0, 8);
+        this.name = request.getName();
+        this.department = request.getDepartment();
+        this.phone = request.getPhone();
+        this.academicStatus = request.getAcademicStatus();
+        this.grade = request.getGrade();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberAcademicStatus.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberAcademicStatus.java
@@ -1,5 +1,5 @@
 package wegrus.clubwebsite.entity.member;
 
 public enum MemberAcademicStatus {
-    ATTENDING, ABSENCE, GRADUATED
+    ATTENDING, ABSENCE, GRADUATED, ETC
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberGrade.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberGrade.java
@@ -1,5 +1,5 @@
 package wegrus.clubwebsite.entity.member;
 
 public enum MemberGrade {
-    FRESHMAN, SOPHOMORE, JUNIOR, SENIOR
+    FRESHMAN, SOPHOMORE, JUNIOR, SENIOR, ETC
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
@@ -6,6 +6,7 @@ public enum MemberRoles {
     ROLE_GUEST,                 // 손님
     ROLE_MEMBER,                // 동아리원
     ROLE_GROUP_EXECUTIVE,       // 그룹 임원
+    ROLE_GROUP_PRESIDENT,       // 그룹 회장
     ROLE_CLUB_EXECUTIVE,        // 동아리 임원
     ROLE_CLUB_PRESIDENT         // 동아리 회장
 }

--- a/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/MemberRoles.java
@@ -1,5 +1,11 @@
 package wegrus.clubwebsite.entity.member;
 
 public enum MemberRoles {
-    ROLE_GUEST, ROLE_MEMBER, ROLE_ADMIN
+    ROLE_RESIGN,                // 탈퇴
+    ROLE_BAN,                   // 재가입 불가
+    ROLE_GUEST,                 // 손님
+    ROLE_MEMBER,                // 동아리원
+    ROLE_GROUP_EXECUTIVE,       // 그룹 임원
+    ROLE_CLUB_EXECUTIVE,        // 동아리 임원
+    ROLE_CLUB_PRESIDENT         // 동아리 회장
 }

--- a/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyBanException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyBanException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class MemberAlreadyBanException extends BusinessException {
+
+    public MemberAlreadyBanException() {
+        super(ErrorCode.MEMBER_ALREADY_BAN);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyResignException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyResignException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class MemberAlreadyResignException extends BusinessException {
+
+    public MemberAlreadyResignException() {
+        super(ErrorCode.MEMBER_ALREADY_RESIGN);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/MemberResignException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberResignException.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class MemberResignException extends BusinessException {
+
+    public MemberResignException(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.MEMBER_CANNOT_RESIGN, errors);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
@@ -3,8 +3,10 @@ package wegrus.clubwebsite.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.member.MemberRole;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
     Optional<MemberRole> findByMemberIdAndRoleId(Long memberId, Long roleId);
+    List<MemberRole> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
@@ -34,6 +34,6 @@ public class JwtUserDetailsUtil implements UserDetailsService {
 
         return new User(String.valueOf(findMember.getId()),
                 UUID.randomUUID().toString(),
-                new ArrayList<>(authorities));
+                authorities);
     }
 }

--- a/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
@@ -22,10 +22,14 @@ public class KakaoUtil {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         headers.set("Authorization", "Bearer " + accessToken);
+
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, headers);
         final ResponseEntity<Map> responseEntity = restTemplate.exchange("https://kapi.kakao.com/v2/user/me", HttpMethod.GET, requestEntity, Map.class);
         final Map response = responseEntity.getBody();
-        return "kakao_" + response.get("id");
+        final String userId = "kakao_" + response.get("id");
+
+        restTemplate.exchange("https://kapi.kakao.com/v1/user/logout", HttpMethod.POST, requestEntity, Map.class);
+        return userId;
     }
 
     public String getAccessTokenFromKakaoAPI(String authorizationCode) {

--- a/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/Board/BoardRepositoryTest.java
@@ -37,7 +37,7 @@ public class BoardRepositoryTest {
 
     @Test
     @DisplayName("게시물 관련 엔티티들 등록 및 확인")
-    public void boardSaveLoad(){
+    public void boardSaveLoad() {
         final Member member = Member.builder()
                 .name("김철수")
                 .department("컴퓨터공학과")

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -495,7 +495,7 @@ public class MemberControllerTest {
         final MockMultipartFile multipartFile = new MockMultipartFile("name", "name.png", "png", new FileInputStream("src/test/resources/static/image.jpg"));
         MemberImageUpdateResponse response = new MemberImageUpdateResponse(Status.SUCCESS, "new url");
         doReturn(response).when(memberService).updateMemberImage(any(MultipartFile.class));
-        
+
         // when
         final ResultActions perform = mockMvc.perform(
                 multipart("/members/image").file(multipartFile)
@@ -579,7 +579,7 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("message").value(REQUEST_AUTHORITY_SUCCESS.getMessage()))
                 .andExpect(jsonPath("data.role").value(MemberRoles.ROLE_MEMBER.name()));
     }
-    
+
     @Test
     @DisplayName("회원 탈퇴 API: 성공")
     void resign_success() throws Exception {

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -271,8 +271,8 @@ public class MemberControllerTest {
         // then
         perform
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("code").value(SIGNIN_FAILURE.getCode()))
-                .andExpect(jsonPath("message").value(SIGNIN_FAILURE.getMessage()))
+                .andExpect(jsonPath("code").value(NEED_TO_SIGNUP.getCode()))
+                .andExpect(jsonPath("message").value(NEED_TO_SIGNUP.getMessage()))
                 .andExpect(jsonPath("data.status").value(Status.FAILURE));
     }
 

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -22,22 +22,28 @@ import wegrus.clubwebsite.config.JwtRequestFilter;
 import wegrus.clubwebsite.config.WebSecurityConfig;
 import wegrus.clubwebsite.controller.MemberController;
 import wegrus.clubwebsite.dto.Status;
+import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
+import wegrus.clubwebsite.exception.MemberResignException;
 import wegrus.clubwebsite.service.MemberService;
 import wegrus.clubwebsite.util.RedisUtil;
 
 import javax.servlet.http.Cookie;
 import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -572,5 +578,48 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("code").value(REQUEST_AUTHORITY_SUCCESS.getCode()))
                 .andExpect(jsonPath("message").value(REQUEST_AUTHORITY_SUCCESS.getMessage()))
                 .andExpect(jsonPath("data.role").value(MemberRoles.ROLE_MEMBER.name()));
+    }
+    
+    @Test
+    @DisplayName("회원 탈퇴 API: 성공")
+    void resign_success() throws Exception {
+        // given
+        final StatusResponse status = new StatusResponse(Status.SUCCESS);
+        doReturn(status).when(memberService).resign();
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                post("/members/resign").with(csrf())
+        );
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(MEMBER_RESIGN_SUCCESS.getCode()))
+                .andExpect(jsonPath("message").value(MEMBER_RESIGN_SUCCESS.getMessage()))
+                .andExpect(jsonPath("data.status").value(Status.SUCCESS));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 API: 실패")
+    void resign_fail() throws Exception {
+        // given
+        final List<ErrorResponse.FieldError> errors = new ArrayList<>();
+        errors.add(new ErrorResponse.FieldError("role", MemberRoles.ROLE_CLUB_PRESIDENT.name(), CLUB_PRESIDENT_CANNOT_RESIGN.getMessage()));
+        doThrow(new MemberResignException(errors)).when(memberService).resign();
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                post("/members/resign").with(csrf())
+        );
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value(MEMBER_CANNOT_RESIGN.getCode()))
+                .andExpect(jsonPath("message").value(MEMBER_CANNOT_RESIGN.getMessage()))
+                .andExpect(jsonPath("errors[0].field").value("role"))
+                .andExpect(jsonPath("errors[0].value").value(MemberRoles.ROLE_CLUB_PRESIDENT.name()))
+                .andExpect(jsonPath("errors[0].reason").value(CLUB_PRESIDENT_CANNOT_RESIGN.getMessage()));
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -159,7 +159,7 @@ public class MemberIntegrationTest {
         return objectMapper.convertValue(responseEntity.getBody().getData(), MemberImageUpdateResponse.class);
     }
 
-    public ValidateEmailResponse validateEmailAPI(String email){
+    public ValidateEmailResponse validateEmailAPI(String email) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
+import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
@@ -172,6 +173,15 @@ public class MemberIntegrationTest {
         final HttpEntity<MultiValueMap<String, MemberRoles>> requestEntity = new HttpEntity<>(map, headers);
         final ResponseEntity<ResultResponse> responseEntity = restTemplate.exchange("/members/authority", HttpMethod.POST, requestEntity, ResultResponse.class);
         return objectMapper.convertValue(responseEntity.getBody().getData(), RequestAuthorityResponse.class);
+    }
+
+    public StatusResponse resignAPI(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+        final HttpEntity<MultiValueMap<String, MemberRoles>> requestEntity = new HttpEntity<>(null, headers);
+        final ResponseEntity<ResultResponse> responseEntity = restTemplate.exchange("/members/resign", HttpMethod.POST, requestEntity, ResultResponse.class);
+        return objectMapper.convertValue(responseEntity.getBody().getData(), StatusResponse.class);
     }
 
     @Test
@@ -391,5 +401,24 @@ public class MemberIntegrationTest {
         // then
         assertThat(response.getStatus()).isEqualTo(Status.SUCCESS);
         assertThat(response.getRole()).isEqualTo(memberRoles);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    void resign() throws Exception {
+        // given
+        final String email = "33339922@inha.edu";
+        final String userId = "1223511210";
+        doReturn(userId).when(kakaoUtil).getUserIdFromKakaoAPI(any(String.class));
+        signupAPI(email, "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.FRESHMAN, userId);
+        final ResponseEntity<ResultResponse> responseEntity = signinAPI("authorizationCode");
+        final MemberSigninSuccessResponse memberSigninSuccessResponse = objectMapper.convertValue(responseEntity.getBody().getData(), MemberSigninSuccessResponse.class);
+        final String accessToken = memberSigninSuccessResponse.getAccessToken();
+
+        // when
+        final StatusResponse response = resignAPI(accessToken);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(Status.SUCCESS);
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
@@ -21,7 +21,7 @@ public class MemberRepositoryTest {
 
     @BeforeEach
     void init() {
-        for(int i = 0; i < 5; i ++) {
+        for (int i = 0; i < 5; i++) {
             final Member member = Member.builder()
                     .name("김만두" + i)
                     .email("1216154" + i + "@inha.edu")

--- a/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
@@ -1,0 +1,115 @@
+package wegrus.clubwebsite.member;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import wegrus.clubwebsite.entity.member.*;
+import wegrus.clubwebsite.repository.MemberRepository;
+import wegrus.clubwebsite.repository.MemberRoleRepository;
+import wegrus.clubwebsite.repository.RoleRepository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class MemberRoleRepositoryTest {
+
+    @Autowired
+    private MemberRoleRepository memberRoleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void init() {
+        final List<String> roles = Arrays.stream(MemberRoles.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String sql = "INSERT INTO ROLES (`role_name`) VALUES(?)";
+        final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, roles.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return roles.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(sql, pss);
+    }
+
+    @Test
+    @DisplayName("회원 PK로 해당 회원의 모든 권한 조회하기")
+    void findAllByMemberId() throws Exception {
+        // given
+        final Member member = Member.builder()
+                .name("김만두")
+                .email("12161542@inha.edu")
+                .department("컴퓨터공학과")
+                .academicStatus(MemberAcademicStatus.ATTENDING)
+                .phone("010-1234-5672")
+                .userId("kakao_124124512541")
+                .grade(MemberGrade.FRESHMAN)
+                .build();
+        memberRepository.save(member);
+        final Optional<Role> guestRole = roleRepository.findByName(MemberRoles.ROLE_GUEST.name());
+        final Optional<Role> guestMember = roleRepository.findByName(MemberRoles.ROLE_MEMBER.name());
+        memberRoleRepository.save(new MemberRole(member, guestMember.get()));
+        memberRoleRepository.save(new MemberRole(member, guestRole.get()));
+
+        // when
+        final List<MemberRole> memberRoles = memberRoleRepository.findAllByMemberId(member.getId());
+
+        // then
+        assertThat(memberRoles.size()).isEqualTo(2);
+    }
+    
+    @Test
+    @DisplayName("Batch delete로 MemberRole 엔티티 여러 개 한 번에 삭제하기")
+    void deleteAllByIdInBatch() throws Exception {
+        // given
+        final Member member = Member.builder()
+                .name("김만두")
+                .email("12161542@inha.edu")
+                .department("컴퓨터공학과")
+                .academicStatus(MemberAcademicStatus.ATTENDING)
+                .phone("010-1234-5672")
+                .userId("kakao_124124512541")
+                .grade(MemberGrade.FRESHMAN)
+                .build();
+        memberRepository.save(member);
+        final Optional<Role> guestRole = roleRepository.findByName(MemberRoles.ROLE_GUEST.name());
+        final Optional<Role> guestMember = roleRepository.findByName(MemberRoles.ROLE_MEMBER.name());
+        memberRoleRepository.save(new MemberRole(member, guestMember.get()));
+        memberRoleRepository.save(new MemberRole(member, guestRole.get()));
+
+        final List<Long> ids = memberRoleRepository.findAllByMemberId(member.getId()).stream()
+                .map(MemberRole::getId)
+                .collect(Collectors.toList());
+
+        // when
+        memberRoleRepository.deleteAllByIdInBatch(ids);
+        
+        // then
+        assertThat(memberRoleRepository.findAllByMemberId(member.getId()).size()).isEqualTo(0);
+    }
+}

--- a/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
@@ -82,7 +82,7 @@ public class MemberRoleRepositoryTest {
         // then
         assertThat(memberRoles.size()).isEqualTo(2);
     }
-    
+
     @Test
     @DisplayName("Batch delete로 MemberRole 엔티티 여러 개 한 번에 삭제하기")
     void deleteAllByIdInBatch() throws Exception {
@@ -108,7 +108,7 @@ public class MemberRoleRepositoryTest {
 
         // when
         memberRoleRepository.deleteAllByIdInBatch(ids);
-        
+
         // then
         assertThat(memberRoleRepository.findAllByMemberId(member.getId()).size()).isEqualTo(0);
     }

--- a/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
@@ -86,7 +85,7 @@ public class MemberServiceTest {
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add((GrantedAuthority) () -> "ROLE_GUEST");
         User user = new User("1", "password", authorities);
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user,null, authorities);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
@@ -428,7 +427,7 @@ public class MemberServiceTest {
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         ReflectionTestUtils.setField(imageUtil, "MEMBER_BASIC_IMAGE_URL", "구 이미지 저장소 url");
-        
+
         // when
         final Executable executable = () -> memberService.updateMemberImage(null);
 
@@ -509,7 +508,7 @@ public class MemberServiceTest {
         // then
         assertThrows(MemberAlreadyHasRoleException.class, executable);
     }
-    
+
     @Test
     @DisplayName("회원 탈퇴: 성공")
     void resign_success() throws Exception {
@@ -539,7 +538,6 @@ public class MemberServiceTest {
         assertThat(member.get().getEmail()).isEqualTo("");
     }
 
-    @WithMockUser(roles = "CLUB_PRESIDENT")
     @Test
     @DisplayName("회원 탈퇴: 실패")
     void resign_fail() throws Exception {
@@ -547,7 +545,7 @@ public class MemberServiceTest {
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("ROLE_CLUB_PRESIDENT"));
         User user = new User("1", "password", authorities);
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user,null, authorities);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         // when


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #35 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 탈퇴 API 추가 
- 회장, 탈퇴 회원, 재가입 불가 회원은 해당 API 호출 불가 -> 400 응답
- 해당 회원의 권한을 모두 지우고, ROLE_RESIGN 권한만 추가
- userId를 제외한 모든 회원 정보 파기

### Member 관련 enum 수정
- MemberAcademicStatus: ETC 추가 -> 회원 탈퇴
- MemberGrade: ETC 추가 -> 회원 탈퇴 or 5학년 이상
- MemberRoles: 권한 세분화
    ![image](https://user-images.githubusercontent.com/68049320/151247963-1127329b-ef43-46dd-9f26-bce1a68d1405.png)

### loadUserByUsername 반환 객체 내부 수정 
- User 객체의 authorities 필드에 List<List> 형식으로 저장하였음  -> 바깥쪽 List 제거

### 로그인 API, 회원가입 API 로직 수정 
- **로그인 API 로직 수정**
  - 존재하지 않는 회원, 탈퇴한 회원, 재가입 불가 회원에 따라 응답 메시지 상이
  - 로그인 성공 시, 카카오 api에서 받은 jwt 만료(카카오 로그아웃) 로직 추가 -> KakaoUtil 참고
- **회원가입 API 로직 수정**
  - 탈퇴한 회원인 경우, 회원가입 폼에 작성한 데이터로 회원 정보 수정 + 권한 수정(Resign -> Guest)
      - ROLE_RESIGN 권한
  - 재가입 불가 회원인 경우 400 응답
      - ROLE_BAN 권한

### SetupConfig 수정
- 서버를 킬 때마다 아래의 작업 수행
  - Roles 테이블 batch delete
  - MemberRoles에 존재하는 권한 JdbcTemplate batch insert

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
