### PR TITLE
게시물 조회 api, 게시판 추가/삭제/조회 api 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -6,14 +6,16 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.entity.post.BoardCategories;
+import wegrus.clubwebsite.entity.post.BoardCategory;
+import wegrus.clubwebsite.entity.post.Boards;
 import wegrus.clubwebsite.repository.BoardCategoryRepository;
+import wegrus.clubwebsite.repository.BoardRepository;
 import wegrus.clubwebsite.repository.RoleRepository;
 
 import javax.annotation.PostConstruct;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Configuration
@@ -22,6 +24,7 @@ public class SetupConfig {
 
     private final RoleRepository roleRepository;
     private final BoardCategoryRepository boardCategoryRepository;
+    private final BoardRepository boardRepository;
     private final JdbcTemplate jdbcTemplate;
 
     @PostConstruct
@@ -67,5 +70,49 @@ public class SetupConfig {
             }
         };
         jdbcTemplate.batchUpdate(categorySql, categoryPss);
+
+        // Boards
+        boardRepository.deleteAllInBatch();
+
+        List<Long> boardCategoryIds = boardCategoryRepository.findAll()
+                .stream()
+                .map(BoardCategory::getId)
+                .collect(Collectors.toList());
+
+        List<Long> boardCategoryIdOrders = Arrays.asList(
+                boardCategoryIds.get(0),
+                boardCategoryIds.get(1),
+                boardCategoryIds.get(1),
+                boardCategoryIds.get(1),
+                boardCategoryIds.get(1),
+                boardCategoryIds.get(2),
+                boardCategoryIds.get(3),
+                boardCategoryIds.get(3),
+                boardCategoryIds.get(3),
+                boardCategoryIds.get(3),
+                boardCategoryIds.get(3),
+                boardCategoryIds.get(3)
+        );
+
+        final List<String> boards = Arrays.stream(Boards.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String boardSql = "INSERT INTO BOARDS (`board_category_id`, `board_name`) VALUES(?, ?)";
+        final BatchPreparedStatementSetter boardPss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, boardCategoryIdOrders.get(i));
+                ps.setString(2, boards.get(i));
+
+            }
+
+            @Override
+            public int getBatchSize() {
+                return boards.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(boardSql, boardPss);
+
     }
 }

--- a/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
@@ -69,6 +69,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/", "/swagger-resources/**", "/swagger-ui/**", "/signup/**", "/signin", "/reissue").permitAll()
                 .antMatchers("/members/**").hasAuthority("ROLE_GUEST")
                 .antMatchers("/posts/**", "/comments/**").hasAuthority("ROLE_MEMBER")
+                .antMatchers("/club/executives/**").hasAuthority("ROLE_CLUB_EXECUTIVE")
                 .anyRequest().authenticated()
                 .and()
 

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -120,7 +120,7 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(DELETE_REPLY_LIKE_SUCCESS, null));
     }
 
-    @ApiOperation(value = "게시판 조회 api")
+    @ApiOperation(value = "게시판 조회")
     @GetMapping("club/executives/boards")
     public ResponseEntity<ResultResponse> viewBoard(){
         final BoardResponse response = postService.viewBoard();
@@ -128,7 +128,7 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(VIEW_BOARD_SUCCESS, response));
     }
 
-    @ApiOperation(value = "게시판 추가 api")
+    @ApiOperation(value = "게시판 추가")
     @PostMapping("club/executives/boards")
     public ResponseEntity<ResultResponse> createBoard(@Validated @RequestBody BoardCreateRequest request) {
         final Long boardId = postService.createBoard(request);

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -12,7 +12,6 @@ import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.service.PostService;
 import wegrus.clubwebsite.service.ReplyService;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -57,7 +56,7 @@ public class PostController {
     @ApiImplicitParam(name = "postId", value = "게시물 순번(PK)", required = true, example = "1")
     @GetMapping("/posts/{postId}")
     public ResponseEntity<ResultResponse> viewPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId){
-        final PostResponse response = postService.view(postId);
+        final PostResponse response = postService.getPost(postId);
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -122,8 +122,8 @@ public class PostController {
 
     @ApiOperation(value = "게시판 조회")
     @GetMapping("club/executives/boards")
-    public ResponseEntity<ResultResponse> viewBoard(){
-        final BoardResponse response = postService.viewBoard();
+    public ResponseEntity<ResultResponse> getBoards(){
+        final BoardResponse response = postService.getBoards();
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_BOARD_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -126,4 +126,13 @@ public class PostController {
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_BOARD_SUCCESS, response));
     }
+
+    @ApiOperation(value = "게시판 추가 api")
+    @PostMapping("club/executives/boards")
+    public ResponseEntity<ResultResponse> createBoard(@Validated @RequestBody BoardCreateRequest request) {
+        final Long boardId = postService.createBoard(request);
+        final BoardCreateResponse response = new BoardCreateResponse(boardId);
+
+        return ResponseEntity.ok(ResultResponse.of(CREATE_BOARD_SUCCESS, response));
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -118,4 +118,12 @@ public class PostController {
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_REPLY_LIKE_SUCCESS, null));
     }
+
+    @ApiOperation(value = "게시판 조회 api")
+    @GetMapping("club/executives/boards")
+    public ResponseEntity<ResultResponse> viewBoard(){
+        final BoardResponse response = postService.viewBoard();
+
+        return ResponseEntity.ok(ResultResponse.of(VIEW_BOARD_SUCCESS, response));
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -1,6 +1,7 @@
 package wegrus.clubwebsite.controller;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +50,15 @@ public class PostController {
         postService.delete(postId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));
+    }
+
+    @ApiOperation(value = "게시물 조회")
+    @ApiImplicitParam(name = "postId", value = "게시물 순번(PK)", required = true, example = "1")
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<ResultResponse> viewPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId){
+        final PostResponse response = postService.view(postId);
+
+        return ResponseEntity.ok(ResultResponse.of(VIEW_POST_SUCCESS, response));
     }
 
     @ApiOperation(value = "게시물 추천")

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
     @ApiOperation(value = "게시물 조회")
     @ApiImplicitParam(name = "postId", value = "게시물 순번(PK)", required = true, example = "1")
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<ResultResponse> viewPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId){
+    public ResponseEntity<ResultResponse> getPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId){
         final PostResponse response = postService.getPost(postId);
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_SUCCESS, response));

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -12,6 +12,7 @@ import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.service.PostService;
 import wegrus.clubwebsite.service.ReplyService;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -134,5 +135,13 @@ public class PostController {
         final BoardCreateResponse response = new BoardCreateResponse(boardId);
 
         return ResponseEntity.ok(ResultResponse.of(CREATE_BOARD_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "게시판 삭제")
+    @DeleteMapping("club/executives/boards/{boardId}")
+    public ResponseEntity<ResultResponse> deleteBoard(@NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId){
+        postService.deleteBoard(boardId);
+
+        return ResponseEntity.ok(ResultResponse.of(DELETE_BOARD_SUCCESS, null));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     REPLY_LIKE_ALREADY_EXIST(400, "B006", "이미 존재하는 댓글 추천입니다."),
     REPLY_LIKE_NOT_FOUND(400, "B007", "댓글 추천이 존재하지 않습니다."),
     BOARD_NOT_FOUND(400, "B008", "존재하지 않는 게시판입니다."),
+    BOARD_CATEGORY_NOT_FOUND(400, "B009", "존재하지 않는 게시판 종류입니다."),
 
     // Member
     MEMBER_NOT_FOUND(400, "M000", "존재하지 않는 회원입니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateRequest.java
@@ -1,0 +1,20 @@
+package wegrus.clubwebsite.dto.post;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class BoardCreateRequest {
+
+    @ApiModelProperty(value = "게시판 카테고리 id", example = "BOARD", required = true)
+    @NotNull(message = "게시판 카테고리 id는 필수입니다.")
+    private Long boardCategoryId;
+
+    @ApiModelProperty(value = "게시판 이름", example = "NEW", required = true)
+    @NotNull(message = "게시판 이름은 필수입니다.")
+    private String boardName;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 public class BoardCreateRequest {
 
-    @ApiModelProperty(value = "게시판 카테고리 id", example = "BOARD", required = true)
+    @ApiModelProperty(value = "게시판 카테고리 id", example = "1", required = true)
     @NotNull(message = "게시판 카테고리 id는 필수입니다.")
     private Long boardCategoryId;
 

--- a/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BoardCreateResponse.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoardCreateResponse {
+    private Long boardId;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/BoardDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BoardDto.java
@@ -1,0 +1,22 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.post.Board;
+
+@Getter
+@NoArgsConstructor
+public class BoardDto {
+
+    private Long boardId;
+    private String boardName;
+    private String boardCategoryName;
+
+    @Builder
+    public BoardDto(Board board){
+        this.boardId = board.getId();
+        this.boardName = board.getName();
+        this.boardCategoryName = board.getBoardCategory().getName();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/BoardResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BoardResponse.java
@@ -1,0 +1,14 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardResponse {
+    private List<BoardDto> boards;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostCreateRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostCreateRequest.java
@@ -16,7 +16,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 public class PostCreateRequest {
 
-    @ApiModelProperty(value = "게시판 종류", example = "BOARD", required = true)
+    @ApiModelProperty(value = "게시판 종류", example = "FREE", required = true)
     @NotNull(message = "게시판 종류는 필수입니다.")
     private String boardName;
 

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -3,6 +3,7 @@ package wegrus.clubwebsite.dto.post;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wegrus.clubwebsite.entity.post.Post;
+import wegrus.clubwebsite.vo.Image;
 import wegrus.clubwebsite.vo.ImageType;
 
 import java.time.LocalDateTime;
@@ -14,10 +15,7 @@ public class PostDto {
     private Long postId;
     private Long memberId;
     private String memberName;
-    private String memberImageUrl;
-    private ImageType memberImageType;
-    private String memberImageName;
-    private String memberImageVvid;
+    private Image image;
     private String board;
     private String boardCategory;
     private String type;
@@ -29,14 +27,11 @@ public class PostDto {
     private Long postView;
     private boolean secretFlag;
 
-    public PostDto(Post post){
+    public PostDto(Post post) {
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
         this.memberName = post.getMember().getStudentId().substring(2, 4) + post.getMember().getName();
-        this.memberImageUrl = post.getMember().getImage().getUrl();
-        this.memberImageType = post.getMember().getImage().getType();
-        this.memberImageName = post.getMember().getImage().getName();
-        this.memberImageVvid = post.getMember().getImage().getUuid();
+        this.image = post.getMember().getImage();
         this.board = post.getBoard().getName();
         this.boardCategory = post.getBoard().getBoardCategory().getName();
         this.type = post.getType().toString();

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -27,7 +27,7 @@ public class PostDto {
     public PostDto(Post post){
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
-        this.memberName = post.getMember().getName();
+        this.memberName = post.getMember().getStudentId().substring(2, 4) + post.getMember().getName();
         this.board = post.getBoard().getName();
         this.boardCategory = post.getBoard().getBoardCategory().getName();
         this.type = post.getType().toString();

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -3,6 +3,7 @@ package wegrus.clubwebsite.dto.post;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wegrus.clubwebsite.entity.post.Post;
+import wegrus.clubwebsite.vo.ImageType;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +14,10 @@ public class PostDto {
     private Long postId;
     private Long memberId;
     private String memberName;
+    private String memberImageUrl;
+    private ImageType memberImageType;
+    private String memberImageName;
+    private String memberImageVvid;
     private String board;
     private String boardCategory;
     private String type;
@@ -28,6 +33,10 @@ public class PostDto {
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
         this.memberName = post.getMember().getStudentId().substring(2, 4) + post.getMember().getName();
+        this.memberImageUrl = post.getMember().getImage().getUrl();
+        this.memberImageType = post.getMember().getImage().getType();
+        this.memberImageName = post.getMember().getImage().getName();
+        this.memberImageVvid = post.getMember().getImage().getUuid();
         this.board = post.getBoard().getName();
         this.boardCategory = post.getBoard().getBoardCategory().getName();
         this.type = post.getType().toString();

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -1,0 +1,42 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.post.Post;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PostDto {
+
+    private Long postId;
+    private Long memberId;
+    private String memberName;
+    private String board;
+    private String boardCategory;
+    private String type;
+    private String title;
+    private String content;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+    private Long postLike;
+    private Long postView;
+    private boolean secretFlag;
+
+    public PostDto(Post post){
+        this.postId = post.getId();
+        this.memberId = post.getMember().getId();
+        this.memberName = post.getMember().getName();
+        this.board = post.getBoard().getName();
+        this.boardCategory = post.getBoard().getBoardCategory().getName();
+        this.type = post.getType().toString();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.createdDate = post.getCreatedDate();
+        this.updatedDate = post.getUpdatedDate();
+        this.postLike = (long) post.getReplies().size();
+        this.postView = (long) post.getViews().size();
+        this.secretFlag = post.isSecretFlag();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostResponse.java
@@ -10,6 +10,17 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostResponse {
-    private PostDto board;
+    private Object board;
     private List<ReplyDto> replies;
+
+    public PostResponse(PostDto board, List<ReplyDto> replies){
+        this.board = board;
+        this.replies = replies;
+    }
+
+    public PostResponse(PostUnknownDto board, List<ReplyDto> replies){
+        this.board = board;
+        this.replies = replies;
+    }
+
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostResponse.java
@@ -1,0 +1,15 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostResponse {
+    private PostDto board;
+    private List<ReplyDto> replies;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
@@ -1,0 +1,41 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.post.Post;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PostUnknownDto {
+    private Long postId;
+    private Long memberId;
+    private String memberName;
+    private String board;
+    private String boardCategory;
+    private String type;
+    private String title;
+    private String content;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+    private Long postLike;
+    private Long postView;
+    private boolean secretFlag;
+
+    public PostUnknownDto(Post post){
+        this.postId = post.getId();
+        this.memberId = post.getMember().getId();
+        this.memberName = "알 수 없음";
+        this.board = post.getBoard().getName();
+        this.boardCategory = post.getBoard().getBoardCategory().getName();
+        this.type = post.getType().toString();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.createdDate = post.getCreatedDate();
+        this.updatedDate = post.getUpdatedDate();
+        this.postLike = (long) post.getReplies().size();
+        this.postView = (long) post.getViews().size();
+        this.secretFlag = post.isSecretFlag();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/ReplyDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/ReplyDto.java
@@ -1,0 +1,30 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.post.Reply;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ReplyDto {
+
+    private Long replyId;
+    private Long memberId;
+    private String memberName;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+    private Long replyLike;
+    private String content;
+
+    public ReplyDto(Reply reply){
+        this.replyId = reply.getId();
+        this.memberId = reply.getMember().getId();
+        this.memberName = reply.getMember().getName();
+        this.createdDate = reply.getCreatedDate();
+        this.updatedDate = reply.getUpdatedDate();
+        this.replyLike = (long) reply.getReplyLikes().size();
+        this.content = reply.getContent();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -37,6 +37,7 @@ public enum ResultCode {
     DELETE_POST_LIKE_SUCCESS(200, "B107", "게시물 추천 해제에 성공하였습니다."),
     CREATE_REPLY_LIKE_SUCCESS(200, "B108", "댓글 추천에 성공하였습니다."),
     DELETE_REPLY_LIKE_SUCCESS(200, "B109", "댓글 추천 해제에 성공하였습니다."),
+    VIEW_BOARD_SUCCESS(200, "B110", "게시판 목록 조회에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -39,6 +39,7 @@ public enum ResultCode {
     DELETE_REPLY_LIKE_SUCCESS(200, "B109", "댓글 추천 해제에 성공하였습니다."),
     VIEW_BOARD_SUCCESS(200, "B110", "게시판 목록 조회에 성공하였습니다."),
     CREATE_BOARD_SUCCESS(200, "B111", "게시판 추가에 성공하였습니다."),
+    DELETE_BOARD_SUCCESS(200, "B112", "게시판 삭제에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -38,6 +38,7 @@ public enum ResultCode {
     CREATE_REPLY_LIKE_SUCCESS(200, "B108", "댓글 추천에 성공하였습니다."),
     DELETE_REPLY_LIKE_SUCCESS(200, "B109", "댓글 추천 해제에 성공하였습니다."),
     VIEW_BOARD_SUCCESS(200, "B110", "게시판 목록 조회에 성공하였습니다."),
+    CREATE_BOARD_SUCCESS(200, "B111", "게시판 추가에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/post/Boards.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/Boards.java
@@ -1,0 +1,16 @@
+package wegrus.clubwebsite.entity.post;
+
+public enum Boards {
+    NOTICE,         // 공지사항
+    IXPLOIT,        // 소모임 IXPLOIT
+    IGDC,           // 소모임 IGDC
+    ALGROUS,        // 소모임 ALGROUS
+    WEBGROUS,       // 소모임 WEBGROUS
+    STUDY,          // 스터디
+    INFO,           // 정보 공유 게시판
+    PROJECT,        // 프로젝트 모집 게시판
+    HOBBY,          // 취미 톡방 게시판
+    Q_A,            // 질문/답변 게시판
+    FREE,           // 자유 게시판
+    SUGGEST         // 건의 사항 게시판
+}

--- a/src/main/java/wegrus/clubwebsite/entity/post/Boards.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/Boards.java
@@ -4,8 +4,8 @@ public enum Boards {
     NOTICE,         // 공지사항
     IXPLOIT,        // 소모임 IXPLOIT
     IGDC,           // 소모임 IGDC
-    ALGROUS,        // 소모임 ALGROUS
-    WEBGROUS,       // 소모임 WEBGROUS
+    ALGORUS,        // 소모임 ALGORUS
+    WEBGRUS,       // 소모임 WEBGRUS
     STUDY,          // 스터디
     INFO,           // 정보 공유 게시판
     PROJECT,        // 프로젝트 모집 게시판

--- a/src/main/java/wegrus/clubwebsite/exception/BoardCategoryNotFoundException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/BoardCategoryNotFoundException.java
@@ -1,0 +1,9 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class BoardCategoryNotFoundException extends BusinessException{
+    public BoardCategoryNotFoundException() {
+        super(ErrorCode.BOARD_CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/ViewRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/ViewRepository.java
@@ -1,7 +1,12 @@
 package wegrus.clubwebsite.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.post.Post;
 import wegrus.clubwebsite.entity.post.View;
 
+import java.util.Optional;
+
 public interface ViewRepository extends JpaRepository<View, Long> {
+    Optional<View> findByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -28,7 +28,7 @@ public class PostService {
     private final ViewRepository viewRepository;
 
     @Transactional
-    public Long create(PostCreateRequest request){
+    public Long create(PostCreateRequest request) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
         final Board board = boardRepository.findByName(request.getBoardName()).orElseThrow(BoardNotFoundException::new);
@@ -48,13 +48,13 @@ public class PostService {
     }
 
     @Transactional
-    public Long update(PostUpdateRequest request){
+    public Long update(PostUpdateRequest request) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 
         final Post post = postRepository.findById(request.getPostId()).orElseThrow(PostNotFoundException::new);
 
-        if(!member.getId().equals(post.getMember().getId())){
+        if (!member.getId().equals(post.getMember().getId())) {
             throw new PostMemberNotMatchException();
         }
 
@@ -63,13 +63,13 @@ public class PostService {
     }
 
     @Transactional
-    public void delete(Long postId){
+    public void delete(Long postId) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 
         final Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
 
-        if(!member.getId().equals(post.getMember().getId())){
+        if (!member.getId().equals(post.getMember().getId())) {
             throw new PostMemberNotMatchException();
         }
 
@@ -86,7 +86,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponse view(Long postId){
+    public PostResponse view(Long postId) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 
@@ -95,7 +95,7 @@ public class PostService {
         // 조회수 추가
         Optional<View> views = viewRepository.findByMemberAndPost(member, post);
 
-        if(views.isEmpty()){
+        if (views.isEmpty()) {
             View view = View.builder()
                     .member(member)
                     .post(post)
@@ -113,7 +113,7 @@ public class PostService {
     }
 
     @Transactional
-    public Long like(Long postId){
+    public Long like(Long postId) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 
@@ -122,7 +122,7 @@ public class PostService {
         Optional<PostLike> postLikes = postLikeRepository.findByMemberAndPost(member, post);
 
         // 추천 기록이 있다면
-        if(postLikes.isPresent()){
+        if (postLikes.isPresent()) {
             throw new PostLikeAlreadyExistException();
         }
 
@@ -137,7 +137,7 @@ public class PostService {
     }
 
     @Transactional
-    public void dislike(Long postId){
+    public void dislike(Long postId) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 
@@ -149,7 +149,7 @@ public class PostService {
     }
 
     @Transactional
-    public BoardResponse viewBoard(){
+    public BoardResponse viewBoard() {
         List<BoardDto> boardDtos = boardRepository.findAll()
                 .stream()
                 .map(BoardDto::new)
@@ -159,7 +159,7 @@ public class PostService {
     }
 
     @Transactional
-    public Long createBoard(BoardCreateRequest request){
+    public Long createBoard(BoardCreateRequest request) {
         final BoardCategory boardCategory = boardCategoryRepository.findById(request.getBoardCategoryId()).orElseThrow(BoardCategoryNotFoundException::new);
 
         Board board = Board.builder()
@@ -171,7 +171,7 @@ public class PostService {
     }
 
     @Transactional
-    public void deleteBoard(Long boardId){
+    public void deleteBoard(Long boardId) {
         boardRepository.deleteById(boardId);
     }
 

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -146,4 +146,15 @@ public class PostService {
 
         postLikeRepository.delete(postLike);
     }
+
+    @Transactional
+    public BoardResponse viewBoard(){
+        List<BoardDto> boardDtos = boardRepository.findAll()
+                .stream()
+                .map(BoardDto::new)
+                .collect(Collectors.toList());
+
+        return new BoardResponse(boardDtos);
+    }
+
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 @Service
 public class PostService {
     private final BoardRepository boardRepository;
+    private final BoardCategoryRepository boardCategoryRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final ReplyRepository replyRepository;
@@ -155,6 +156,18 @@ public class PostService {
                 .collect(Collectors.toList());
 
         return new BoardResponse(boardDtos);
+    }
+
+    @Transactional
+    public Long createBoard(BoardCreateRequest request){
+        final BoardCategory boardCategory = boardCategoryRepository.findById(request.getBoardCategoryId()).orElseThrow(BoardCategoryNotFoundException::new);
+
+        Board board = Board.builder()
+                .name(request.getBoardName())
+                .boardCategory(boardCategory)
+                .build();
+
+        return boardRepository.save(board).getId();
     }
 
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -148,8 +148,8 @@ public class PostService {
         postLikeRepository.delete(postLike);
     }
 
-    @Transactional
-    public BoardResponse viewBoard() {
+    @Transactional(readOnly = true)
+    public BoardResponse getBoards() {
         List<BoardDto> boardDtos = boardRepository.findAll()
                 .stream()
                 .map(BoardDto::new)

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -5,6 +5,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wegrus.clubwebsite.dto.post.*;
+import wegrus.clubwebsite.entity.member.MemberRole;
+import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.entity.member.Role;
 import wegrus.clubwebsite.entity.post.*;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.exception.*;
@@ -12,6 +15,7 @@ import wegrus.clubwebsite.repository.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -22,6 +26,7 @@ public class PostService {
     private final BoardCategoryRepository boardCategoryRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final MemberRoleRepository memberRoleRepository;
     private final ReplyRepository replyRepository;
     private final PostLikeRepository postLikeRepository;
     private final ReplyLikeRepository replyLikeRepository;
@@ -108,6 +113,14 @@ public class PostService {
                 .stream()
                 .map(ReplyDto::new)
                 .collect(Collectors.toList());
+
+        List<MemberRole> memberRoles = memberRoleRepository.findAllByMemberId(post.getMember().getId());
+        List<String> roles = memberRoles.stream()
+                .map(s -> s.getRole().getName())
+                .collect(Collectors.toList());
+
+        if(roles.contains(MemberRoles.ROLE_BAN.name()) || roles.contains(MemberRoles.ROLE_RESIGN.name()))
+            return new PostResponse(new PostUnknownDto(post), replies);
 
         return new PostResponse(new PostDto(post), replies);
     }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -170,4 +170,9 @@ public class PostService {
         return boardRepository.save(board).getId();
     }
 
+    @Transactional
+    public void deleteBoard(Long boardId){
+        boardRepository.deleteById(boardId);
+    }
+
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -86,7 +86,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponse view(Long postId) {
+    public PostResponse getPost(Long postId) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberNotFoundException::new);
 


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #32
- Resolve #39 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 게시물 조회 api 추가
- 게시물을 클릭한 유저의 조회 기록이 Views에 없다면, 조회 기록 추가
- 게시물 조회에 필요한 데이터들 반환

### SetupConfig 수정
- 서버를 킬때마다 기본 게시판 종류가 다 저장되도록 변경

### 게시판 추가 api 추가
- 동아리 임원만 접근 가능, 게시물 카테고리 id와 함께 이름을 입력하면 추가 가능
- security 설정 완료

### 게시판 삭제 api 추가
- 동아리 임원만 접근 가능, 입력받은 boardId와 맞는 게시판 삭제
- 우선 게시판 데이터는 모두 보관

### 게시판 조회 api 추가
- 동아리 임원만 접근 가능, 모든 게시판 정보 반환

### 게시물 저장시 작성자 이름 형식 변경
- 기존 작성자 이름 -> 학번 + 작성자 이름으로 변경
- ex) 19이도경
## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- 동아리 임원의 실수로 게시판을 삭제할 우려가 있어, 우선 게시판 데이터는 제외하고 게시판만 삭제되도록 구현하였습니다.
- 게시물 조회 중 추천수, 댓글 목록 가져올 시 쿼리 다수 발생
  - @EntityGraph로 해결 가능해보이나, #43 에서 추천순, 댓글 순으로 게시물 목록 조회시에 어려움을 겪은 문제점과 원인이 겹침
  -  #43 에서 다른 방법으로 해결


## 📑References
> 참고한 사이트가 있다면 공유해주세요.



## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
