### PR TITLE
게시물 목록 조회 api 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -147,12 +147,12 @@ public class PostController {
 
     @ApiOperation(value = "게시물 목록 조회")
     @GetMapping("boards/{boardId}")
-    public ResponseEntity<ResultResponse> viewPostList(
+    public ResponseEntity<ResultResponse> getPostList(
             @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
             @Validated @NotNull(message = "페이지 번호는 필수입니다.")@RequestParam Integer page,
             @Validated @NotNull(message = "페이지 크기는 필수입니다.")@RequestParam Integer pageSize,
             @Validated @NotNull(message = "타입은 필수입니다.")@RequestParam PostListType type){
-        final PostListResponse response = postService.viewList(page, pageSize, boardId, type);
+        final PostListResponse response = postService.getList(page, pageSize, boardId, type);
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_LIST_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -9,10 +9,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import wegrus.clubwebsite.dto.post.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.entity.post.PostListType;
 import wegrus.clubwebsite.service.PostService;
 import wegrus.clubwebsite.service.ReplyService;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -143,5 +143,17 @@ public class PostController {
         postService.deleteBoard(boardId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_BOARD_SUCCESS, null));
+    }
+
+    @ApiOperation(value = "게시물 목록 조회")
+    @GetMapping("boards/{boardId}")
+    public ResponseEntity<ResultResponse> viewPostList(
+            @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
+            @Validated @NotNull(message = "페이지 번호는 필수입니다.")@RequestParam Integer page,
+            @Validated @NotNull(message = "페이지 크기는 필수입니다.")@RequestParam Integer pageSize,
+            @Validated @NotNull(message = "타입은 필수입니다.")@RequestParam PostListType type){
+        final PostListResponse response = postService.viewList(page, pageSize, boardId, type);
+
+        return ResponseEntity.ok(ResultResponse.of(VIEW_POST_LIST_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     REPLY_LIKE_NOT_FOUND(400, "B007", "댓글 추천이 존재하지 않습니다."),
     BOARD_NOT_FOUND(400, "B008", "존재하지 않는 게시판입니다."),
     BOARD_CATEGORY_NOT_FOUND(400, "B009", "존재하지 않는 게시판 종류입니다."),
+    POST_LIST_NOT_FOUND(400, "B010", "존재하지 않는 게시물 목록입니다."),
 
     // Member
     MEMBER_NOT_FOUND(400, "M000", "존재하지 않는 회원입니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -26,6 +26,7 @@ public class PostDto {
     private LocalDateTime createdDate;
     private LocalDateTime updatedDate;
     private Integer postLike;
+    private Integer postReplies;
     private Integer postView;
     private boolean secretFlag;
 
@@ -45,6 +46,7 @@ public class PostDto {
         this.createdDate = post.getCreatedDate();
         this.updatedDate = post.getUpdatedDate();
         this.postLike = post.getPostLikeNum();
+        this.postReplies = post.getReplyNum();
         this.postView = post.getViews().size();
         this.secretFlag = post.isSecretFlag();
     }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -35,7 +35,7 @@ public class PostDto {
         this.content = post.getContent();
         this.createdDate = post.getCreatedDate();
         this.updatedDate = post.getUpdatedDate();
-        this.postLike = (long) post.getReplies().size();
+        this.postLike = (long) post.getPostLikes().size();
         this.postView = (long) post.getViews().size();
         this.secretFlag = post.isSecretFlag();
     }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostListDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostListDto.java
@@ -8,8 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-public class PostDto {
-
+public class PostListDto {
     private Long postId;
     private Long memberId;
     private String memberName;
@@ -17,14 +16,14 @@ public class PostDto {
     private String boardCategory;
     private String type;
     private String title;
-    private String content;
     private LocalDateTime createdDate;
     private LocalDateTime updatedDate;
     private Integer postLike;
     private Integer postView;
+    private Integer postReplies;
     private boolean secretFlag;
 
-    public PostDto(Post post){
+    public PostListDto(Post post){
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
         this.memberName = post.getMember().getStudentId().substring(2, 4) + post.getMember().getName();
@@ -32,11 +31,11 @@ public class PostDto {
         this.boardCategory = post.getBoard().getBoardCategory().getName();
         this.type = post.getType().toString();
         this.title = post.getTitle();
-        this.content = post.getContent();
         this.createdDate = post.getCreatedDate();
         this.updatedDate = post.getUpdatedDate();
         this.postLike = post.getPostLikeNum();
         this.postView = post.getViews().size();
+        this.postReplies = post.getReplyNum();
         this.secretFlag = post.isSecretFlag();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostListResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostListResponse.java
@@ -1,0 +1,11 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+public class PostListResponse {
+    private Page<PostListDto> posts;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
@@ -19,8 +19,9 @@ public class PostUnknownDto {
     private String content;
     private LocalDateTime createdDate;
     private LocalDateTime updatedDate;
-    private Long postLike;
-    private Long postView;
+    private Integer postLike;
+    private Integer postReplies;
+    private Integer postView;
     private boolean secretFlag;
 
     public PostUnknownDto(Post post){
@@ -34,8 +35,9 @@ public class PostUnknownDto {
         this.content = post.getContent();
         this.createdDate = post.getCreatedDate();
         this.updatedDate = post.getUpdatedDate();
-        this.postLike = (long) post.getReplies().size();
-        this.postView = (long) post.getViews().size();
+        this.postLike = post.getPostLikeNum();
+        this.postReplies = post.getReplyNum();
+        this.postView = post.getViews().size();
         this.secretFlag = post.isSecretFlag();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -40,6 +40,7 @@ public enum ResultCode {
     VIEW_BOARD_SUCCESS(200, "B110", "게시판 목록 조회에 성공하였습니다."),
     CREATE_BOARD_SUCCESS(200, "B111", "게시판 추가에 성공하였습니다."),
     DELETE_BOARD_SUCCESS(200, "B112", "게시판 삭제에 성공하였습니다."),
+    VIEW_POST_LIST_SUCCESS(200, "B113", "게시판 목록 조회에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/post/Post.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/Post.java
@@ -70,6 +70,12 @@ public class Post {
     @Column(name = "post_state", nullable = false)
     private PostState state;
 
+    @Column(name = "post_like_num")
+    private Integer postLikeNum;
+
+    @Column(name = "reply_num")
+    private Integer replyNum;
+
     @Builder
     public Post(Member member, Board board, PostType type, String title, String content, boolean secretFlag, PostState state){
         this.member = member;
@@ -79,11 +85,21 @@ public class Post {
         this.content = content;
         this.secretFlag = secretFlag;
         this.state = state;
+        this.postLikeNum = 0;
+        this.replyNum = 0;
     }
 
     public void update(PostUpdateRequest request){
         this.title = request.getTitle();
         this.content = request.getContent();
         this.secretFlag = request.isSecretFlag();
+    }
+
+    public void likeNum(Integer postLikeNum){
+        this.postLikeNum = postLikeNum;
+    }
+
+    public void replyNum(Integer replyNum){
+        this.replyNum = replyNum;
     }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/post/PostListType.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/PostListType.java
@@ -1,0 +1,7 @@
+package wegrus.clubwebsite.entity.post;
+
+public enum PostListType {
+    LASTEST,        // 최신순
+    LIKEEST,        // 추천순
+    REPLYEST        // 댓글순
+}

--- a/src/main/java/wegrus/clubwebsite/exception/PostListTypeNotFoundException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/PostListTypeNotFoundException.java
@@ -1,0 +1,9 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class PostListTypeNotFoundException extends BusinessException {
+    public PostListTypeNotFoundException() {
+        super(ErrorCode.POST_LIST_NOT_FOUND);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
@@ -1,8 +1,14 @@
 package wegrus.clubwebsite.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.post.Board;
 import wegrus.clubwebsite.entity.post.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findByBoardOrderByTypeDescIdDesc(Board board, Pageable pageable);
+    Page<Post> findByBoardOrderByTypeDescPostLikeNumDescIdDesc(Board board, Pageable pageable);
+    Page<Post> findByBoardOrderByTypeDescReplyNumDescIdDesc(Board board, Pageable pageable);
 
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -1,6 +1,10 @@
 package wegrus.clubwebsite.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -133,6 +137,8 @@ public class PostService {
 
         postLikeRepository.save(postLike);
 
+        post.likeNum(post.getPostLikeNum()+1);
+
         return postLike.getId();
     }
 
@@ -146,6 +152,8 @@ public class PostService {
         final PostLike postLike = postLikeRepository.findByMemberAndPost(member, post).orElseThrow(PostLikeNotFoundException::new);
 
         postLikeRepository.delete(postLike);
+
+        post.likeNum(post.getPostLikeNum()-1);
     }
 
     @Transactional
@@ -173,6 +181,43 @@ public class PostService {
     @Transactional
     public void deleteBoard(Long boardId){
         boardRepository.deleteById(boardId);
+    }
+
+    @Transactional
+    public PostListResponse viewList(Integer page, Integer pageSize, Long boardId, PostListType type){
+        Pageable pageable = PageRequest.of(page, pageSize);
+        final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+
+        if(type == PostListType.LASTEST){
+            Page<Post> posts = postRepository.findByBoardOrderByTypeDescIdDesc(board, pageable);
+
+            List<PostListDto> postDtos = posts.stream()
+                    .map(PostListDto::new)
+                    .collect(Collectors.toList());
+
+            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+        }
+        else if(type == PostListType.LIKEEST){
+            Page<Post> posts = postRepository.findByBoardOrderByTypeDescPostLikeNumDescIdDesc(board, pageable);
+
+            List<PostListDto> postDtos = posts.stream()
+                    .map(PostListDto::new)
+                    .collect(Collectors.toList());
+
+            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+        }
+        else if(type == PostListType.REPLYEST){
+            Page<Post> posts = postRepository.findByBoardOrderByTypeDescReplyNumDescIdDesc(board, pageable);
+
+            List<PostListDto> postDtos = posts.stream()
+                    .map(PostListDto::new)
+                    .collect(Collectors.toList());
+
+            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+        }
+        else{
+            throw new PostListTypeNotFoundException();
+        }
     }
 
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -197,7 +197,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostListResponse viewList(Integer page, Integer pageSize, Long boardId, PostListType type){
+    public PostListResponse getList(Integer page, Integer pageSize, Long boardId, PostListType type){
         Pageable pageable = PageRequest.of(page, pageSize);
         final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
 

--- a/src/main/java/wegrus/clubwebsite/service/ReplyService.java
+++ b/src/main/java/wegrus/clubwebsite/service/ReplyService.java
@@ -42,6 +42,8 @@ public class ReplyService {
                 .state(replyState)
                 .build();
 
+        post.replyNum(post.getReplyNum()+1);
+
         return replyRepository.save(reply).getId();
     }
 
@@ -52,9 +54,13 @@ public class ReplyService {
 
         final Reply reply = replyRepository.findById(commentId).orElseThrow(ReplyNotFoundException::new);
 
+        final Post post = reply.getPost();
+
         if(!member.getId().equals(reply.getMember().getId())) {
             throw new ReplyMemberNotMatchException();
         }
+
+        post.replyNum(post.getReplyNum()-1);
 
         // 댓글 추천수 제거
         replyLikeRepository.deleteReplyLikesByReply(reply);


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #34 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### Post 엔티티에 postLikeNum, replyNum 추가
- 게시물 조회, 게시물 목록 조회 시 추천 수, 댓글 수 자주 사용함
  - 이에 따른 추가 쿼리 발생
- 게시물 목록 조회 중 추천순, 댓글순 구현시 문제
  - left outer join을 사용해도 Post 엔티티와 연관된 Post_Likes, Replies 데이터의 개수로 sort하는데 어려움을 겪음
- 따라서 post 엔티티에 postLikeNum, replyNum 추가하기로 결정
- 관련 api(게시물 작성/추천/추천 해제, 댓글 작성/삭제, 게시물 조회) postman 및 swagger로 테스트 완료

### 게시물 목록 조회 api 추가
- 최신순, 댓글순, 추천순 type에 따른 구현 완료
- 모든 경우에 공지사항을 우선적으로 페이징, 그 후 일반 글
- postman 및 swagger로 테스트 완료

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
