### PR TITLE
회원 탈퇴 API -> 이메일 인증 로직 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -202,7 +202,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "이메일 인증 코드 발송", notes = "30분간 유효한 임의의 6자리 난수를 회원의 이메일로 발송합니다.")
-    @PatchMapping("/members/verify")
+    @PostMapping("/members/verify")
     public ResponseEntity<ResultResponse> sendCertificationCode() {
         final StatusResponse response = memberService.sendRandomCode();
 

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -195,9 +195,17 @@ public class MemberController {
 
     @ApiOperation(value = "회원 탈퇴")
     @PostMapping("/members/resign")
-    public ResponseEntity<ResultResponse> resign() {
-        final StatusResponse response = memberService.resign();
+    public ResponseEntity<ResultResponse> resign(@RequestParam String certificationCode) {
+        final StatusResponse response = memberService.resign(certificationCode);
 
         return ResponseEntity.ok(ResultResponse.of(MEMBER_RESIGN_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "이메일 인증 코드 발송", notes = "30분간 유효한 임의의 6자리 난수를 회원의 이메일로 발송합니다.")
+    @PatchMapping("/members/verify")
+    public ResponseEntity<ResultResponse> sendCertificationCode() {
+        final StatusResponse response = memberService.sendRandomCode();
+
+        return ResponseEntity.ok(ResultResponse.of(SEND_CERTIFICATION_CODE_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     CLUB_PRESIDENT_CANNOT_RESIGN(400, "M009", "동아리 회장은 회원 탈퇴를 할 수 없습니다."),
     MEMBER_ALREADY_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
     MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
+    CERTIFICATION_CODE_INVALID(400, "M012", "유효하지 않은 인증 코드입니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -25,6 +25,7 @@ public enum ResultCode {
     MEMBER_RESIGN_SUCCESS(200, "M114", "회원 탈퇴에 성공하였습니다."),
     NEED_TO_REJOIN(200, "M115", "탈퇴한 회원입니다. 회원 가입을 먼저 해주세요."),
     BANNED_USER(200, "M116", "강제 탈퇴된 회원입니다."),
+    SEND_CERTIFICATION_CODE_SUCCESS(200, "M117", "회원의 이메일로 인증 코드 발송에 성공하였습니다."),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/service/CertificationCodeInvalidException.java
+++ b/src/main/java/wegrus/clubwebsite/service/CertificationCodeInvalidException.java
@@ -1,0 +1,11 @@
+package wegrus.clubwebsite.service;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.exception.BusinessException;
+
+public class CertificationCodeInvalidException extends BusinessException {
+
+    public CertificationCodeInvalidException() {
+        super(ErrorCode.CERTIFICATION_CODE_INVALID);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/service/MailService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MailService.java
@@ -5,6 +5,8 @@ import javax.mail.MessagingException;
 public interface MailService {
 
     String VERIFY_SCHOOL_EMAIL_SUBJECT = "[IGRUS] 본인 이메일 인증 안내";
+    String VERIFY_CODE = "[IGRUS] 인증 코드 안내";
     String SENDER = "GraduProject11@gmail.com";
     void sendSchoolMailVerification(String receiver, String key) throws MessagingException;
+    int sendCertificationCode(String email);
 }

--- a/src/main/java/wegrus/clubwebsite/service/MailServiceGmail.java
+++ b/src/main/java/wegrus/clubwebsite/service/MailServiceGmail.java
@@ -2,6 +2,7 @@ package wegrus.clubwebsite.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -55,5 +56,18 @@ public class MailServiceGmail implements MailService {
         helper.setText(body, true);
 
         mailSender.send(mimeMessage);
+    }
+
+    @Override
+    public int sendCertificationCode(String receiver) {
+        final int code = (int) (Math.random() * 1000000);
+        final SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(receiver);
+        message.setFrom(SENDER);
+        message.setSubject(VERIFY_CODE);
+        message.setTo(String.valueOf(code));
+
+        mailSender.send(message);
+        return code;
     }
 }

--- a/src/main/java/wegrus/clubwebsite/service/MailServiceGmail.java
+++ b/src/main/java/wegrus/clubwebsite/service/MailServiceGmail.java
@@ -65,7 +65,7 @@ public class MailServiceGmail implements MailService {
         message.setTo(receiver);
         message.setFrom(SENDER);
         message.setSubject(VERIFY_CODE);
-        message.setTo(String.valueOf(code));
+        message.setText(String.valueOf(code));
 
         mailSender.send(message);
         return code;

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -287,7 +287,7 @@ public class MemberService {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         final int code = mailService.sendCertificationCode(member.getEmail());
-        redisUtil.set(member.getEmail(), code, 30);
+        redisUtil.set(member.getEmail(), String.valueOf(code), 30);
 
         return new StatusResponse(Status.SUCCESS);
     }

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -243,21 +243,26 @@ public class MemberService {
         return new RequestAuthorityResponse(Status.SUCCESS, memberRoles);
     }
 
-    public StatusResponse resign() {
+    @Transactional
+    public StatusResponse resign(String certificationCode) {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        final Long memberId = Long.valueOf(authentication.getName());
         validateMemberRole(authentication);
 
-        final Long memberId = Long.valueOf(authentication.getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        final String code = (String) redisUtil.get(member.getEmail());
+        if (code == null || !code.equals(certificationCode))
+            throw new CertificationCodeInvalidException();
+
         final Role role = roleRepository.findByName(MemberRoles.ROLE_RESIGN.name()).orElseThrow(MemberRoleNotFoundException::new);
         final MemberRole memberRole = new MemberRole(member, role);
-
         final List<Long> ids = memberRoleRepository.findAllByMemberId(memberId).stream()
                 .map(MemberRole::getId)
                 .collect(Collectors.toList());
         memberRoleRepository.deleteAllByIdInBatch(ids);
         memberRoleRepository.save(memberRole);
         member.resign();
+        redisUtil.delete(member.getEmail());
 
         return new StatusResponse(Status.SUCCESS);
     }
@@ -276,5 +281,14 @@ public class MemberService {
                 });
         if (!errors.isEmpty())
             throw new MemberResignException(errors);
+    }
+
+    public StatusResponse sendRandomCode() {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        final int code = mailService.sendCertificationCode(member.getEmail());
+        redisUtil.set(member.getEmail(), code, 30);
+
+        return new StatusResponse(Status.SUCCESS);
     }
 }

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -585,11 +585,13 @@ public class MemberControllerTest {
     void resign_success() throws Exception {
         // given
         final StatusResponse status = new StatusResponse(Status.SUCCESS);
-        doReturn(status).when(memberService).resign();
+        doReturn(status).when(memberService).resign("123123");
 
         // when
         final ResultActions perform = mockMvc.perform(
                 post("/members/resign").with(csrf())
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("certificationCode", "123123")
         );
 
         // then
@@ -606,11 +608,13 @@ public class MemberControllerTest {
         // given
         final List<ErrorResponse.FieldError> errors = new ArrayList<>();
         errors.add(new ErrorResponse.FieldError("role", MemberRoles.ROLE_CLUB_PRESIDENT.name(), CLUB_PRESIDENT_CANNOT_RESIGN.getMessage()));
-        doThrow(new MemberResignException(errors)).when(memberService).resign();
+        doThrow(new MemberResignException(errors)).when(memberService).resign("123123");
 
         // when
         final ResultActions perform = mockMvc.perform(
                 post("/members/resign").with(csrf())
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("certificationCode", "123123")
         );
 
         // then


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #40 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 탈퇴 API: 이메일 인증 로직 추가
- 인증 코드(6자리)를 파라미터에 추가, 해당 인증 코드가 유효한지 검증한 후 회원 탈퇴 로직 수행
- 인증 코드가 유효하지 않으면 400 응답

### 이메일 인증 코드 발송 API 추가
- 6자리 난수를 생성하여, 현재 회원의 이메일로 발송
- {email, code} 형태로 redis에 30분간 저장

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
