### PR TITLE
제목, 제목+내용, 작성자 검색 api 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -27,7 +27,7 @@ public class PostController {
 
     @ApiOperation(value = "게시물 등록")
     @PostMapping("/posts")
-    public ResponseEntity<ResultResponse> createPost(@Validated @RequestBody PostCreateRequest request){
+    public ResponseEntity<ResultResponse> createPost(@Validated @RequestBody PostCreateRequest request) {
         final Long postId = postService.create(request);
         final PostCreateResponse response = new PostCreateResponse(postId);
 
@@ -37,7 +37,7 @@ public class PostController {
     @ApiOperation(value = "게시물 수정")
     @PutMapping("/posts")
     public ResponseEntity<ResultResponse> updatePost(
-            @Validated @RequestBody PostUpdateRequest request){
+            @Validated @RequestBody PostUpdateRequest request) {
         final Long postId = postService.update(request);
         final PostUpdateResponse response = new PostUpdateResponse(postId);
 
@@ -47,7 +47,7 @@ public class PostController {
     @ApiOperation(value = "게시물 삭제")
     @DeleteMapping("/posts")
     public ResponseEntity<ResultResponse> deletePost(
-            @Validated @NotNull(message = "게시물 id는 필수입니다.")@RequestParam Long postId){
+            @Validated @NotNull(message = "게시물 id는 필수입니다.") @RequestParam Long postId) {
         postService.delete(postId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));
@@ -56,7 +56,7 @@ public class PostController {
     @ApiOperation(value = "게시물 조회")
     @ApiImplicitParam(name = "postId", value = "게시물 순번(PK)", required = true, example = "1")
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<ResultResponse> getPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId){
+    public ResponseEntity<ResultResponse> getPost(@NotNull(message = "게시물 id는 필수입니다.") @PathVariable Long postId) {
         final PostResponse response = postService.getPost(postId);
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_SUCCESS, response));
@@ -65,7 +65,7 @@ public class PostController {
     @ApiOperation(value = "게시물 추천")
     @PostMapping("/posts/like")
     public ResponseEntity<ResultResponse> likePost(
-            @Validated @NotNull(message = "게시물 id는 필수입니다.")@RequestParam Long postId){
+            @Validated @NotNull(message = "게시물 id는 필수입니다.") @RequestParam Long postId) {
         final Long postLikeId = postService.like(postId);
         final PostLikeCreateResponse response = new PostLikeCreateResponse(postLikeId);
 
@@ -76,7 +76,7 @@ public class PostController {
     @ApiOperation(value = "게시물 추천 해제")
     @DeleteMapping("/posts/like")
     public ResponseEntity<ResultResponse> dislikePost(
-            @Validated @NotNull(message = "게시물 id는 필수입니다.")@RequestParam Long postId){
+            @Validated @NotNull(message = "게시물 id는 필수입니다.") @RequestParam Long postId) {
         postService.dislike(postId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_LIKE_SUCCESS, null));
@@ -85,7 +85,7 @@ public class PostController {
     @ApiOperation(value = "댓글 등록")
     @PostMapping("/comments")
     public ResponseEntity<ResultResponse> createComment(
-            @Validated @RequestBody ReplyCreateRequest request){
+            @Validated @RequestBody ReplyCreateRequest request) {
         final Long replyId = replyService.create(request);
         final ReplyCreateResponse response = new ReplyCreateResponse(replyId);
 
@@ -95,7 +95,7 @@ public class PostController {
     @ApiOperation(value = "댓글 삭제")
     @DeleteMapping("/comments")
     public ResponseEntity<ResultResponse> deleteComment(
-            @Validated @NotNull(message = "댓글 id는 필수입니다.")@RequestParam Long replyId){
+            @Validated @NotNull(message = "댓글 id는 필수입니다.") @RequestParam Long replyId) {
         replyService.delete(replyId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_REPLY_SUCCESS, null));
@@ -104,7 +104,7 @@ public class PostController {
     @ApiOperation(value = "댓글 추천")
     @PostMapping("/comments/like")
     public ResponseEntity<ResultResponse> likeComment(
-            @Validated @NotNull(message = "댓글 id는 필수입니다.")@RequestParam Long replyId){
+            @Validated @NotNull(message = "댓글 id는 필수입니다.") @RequestParam Long replyId) {
         final Long replyLikeId = replyService.like(replyId);
         final ReplyLikeCreateResponse response = new ReplyLikeCreateResponse(replyLikeId);
 
@@ -114,7 +114,7 @@ public class PostController {
     @ApiOperation(value = "댓글 추천 해제")
     @DeleteMapping("/comments/like")
     public ResponseEntity<ResultResponse> dislikeComment(
-            @Validated @NotNull(message = "댓글 id는 필수입니다.")@RequestParam Long replyId){
+            @Validated @NotNull(message = "댓글 id는 필수입니다.") @RequestParam Long replyId) {
         replyService.dislike(replyId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_REPLY_LIKE_SUCCESS, null));
@@ -122,7 +122,7 @@ public class PostController {
 
     @ApiOperation(value = "게시판 조회")
     @GetMapping("club/executives/boards")
-    public ResponseEntity<ResultResponse> getBoards(){
+    public ResponseEntity<ResultResponse> getBoards() {
         final BoardResponse response = postService.getBoards();
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_BOARD_SUCCESS, response));
@@ -139,7 +139,7 @@ public class PostController {
 
     @ApiOperation(value = "게시판 삭제")
     @DeleteMapping("club/executives/boards/{boardId}")
-    public ResponseEntity<ResultResponse> deleteBoard(@NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId){
+    public ResponseEntity<ResultResponse> deleteBoard(@NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId) {
         postService.deleteBoard(boardId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_BOARD_SUCCESS, null));
@@ -149,11 +149,24 @@ public class PostController {
     @GetMapping("boards/{boardId}")
     public ResponseEntity<ResultResponse> getPostList(
             @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
-            @Validated @NotNull(message = "페이지 번호는 필수입니다.")@RequestParam Integer page,
-            @Validated @NotNull(message = "페이지 크기는 필수입니다.")@RequestParam Integer pageSize,
-            @Validated @NotNull(message = "타입은 필수입니다.")@RequestParam PostListType type){
+            @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
+            @Validated @NotNull(message = "페이지 크기는 필수입니다.") @RequestParam Integer pageSize,
+            @Validated @NotNull(message = "타입은 필수입니다.") @RequestParam PostListType type) {
         final PostListResponse response = postService.getList(page, pageSize, boardId, type);
 
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_LIST_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "제목 검색")
+    @GetMapping("search/writer/{boardId}")
+    public ResponseEntity<ResultResponse> searchByWriter(
+            @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
+            @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
+            @Validated @NotNull(message = "페이지 크기는 필수입니다.") @RequestParam Integer pageSize,
+            @Validated @NotNull(message = "타입은 필수입니다.") @RequestParam PostListType type,
+            @Validated @NotNull(message = "검색어는 필수입니다.") @RequestParam String keyword) {
+        final PostListResponse response = postService.searchByWriter(page, pageSize, boardId, type, keyword);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_WRITER_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -159,13 +159,13 @@ public class PostController {
 
     @ApiOperation(value = "제목 검색")
     @GetMapping("search/writer/{boardId}")
-    public ResponseEntity<ResultResponse> searchByWriter(
+    public ResponseEntity<ResultResponse> searchByTitle(
             @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
             @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
             @Validated @NotNull(message = "페이지 크기는 필수입니다.") @RequestParam Integer pageSize,
             @Validated @NotNull(message = "타입은 필수입니다.") @RequestParam PostListType type,
             @Validated @NotNull(message = "검색어는 필수입니다.") @RequestParam String keyword) {
-        final PostListResponse response = postService.searchByWriter(page, pageSize, boardId, type, keyword);
+        final PostListResponse response = postService.searchByTitle(page, pageSize, boardId, type, keyword);
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_WRITER_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -157,6 +157,19 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(VIEW_POST_LIST_SUCCESS, response));
     }
 
+    @ApiOperation(value = "작성자 검색")
+    @GetMapping("search/writer/{boardId}")
+    public ResponseEntity<ResultResponse> searchByWriter(
+            @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
+            @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
+            @Validated @NotNull(message = "페이지 크기는 필수입니다.") @RequestParam Integer pageSize,
+            @Validated @NotNull(message = "타입은 필수입니다.") @RequestParam PostListType type,
+            @Validated @NotNull(message = "검색어는 필수입니다.") @RequestParam String keyword) {
+        final PostListResponse response = postService.searchByWriter(page, pageSize, boardId, type, keyword);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_WRITER_SUCCESS, response));
+    }
+
     @ApiOperation(value = "제목 검색")
     @GetMapping("search/title/{boardId}")
     public ResponseEntity<ResultResponse> searchByTitle(

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -158,7 +158,7 @@ public class PostController {
     }
 
     @ApiOperation(value = "제목 검색")
-    @GetMapping("search/writer/{boardId}")
+    @GetMapping("search/title/{boardId}")
     public ResponseEntity<ResultResponse> searchByTitle(
             @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
             @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
@@ -167,6 +167,6 @@ public class PostController {
             @Validated @NotNull(message = "검색어는 필수입니다.") @RequestParam String keyword) {
         final PostListResponse response = postService.searchByTitle(page, pageSize, boardId, type, keyword);
 
-        return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_WRITER_SUCCESS, response));
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_TITLE_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -182,4 +182,17 @@ public class PostController {
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_TITLE_SUCCESS, response));
     }
+
+    @ApiOperation(value = "제목+내용 검색")
+    @GetMapping("search/all/{boardId}")
+    public ResponseEntity<ResultResponse> searchByAll(
+            @NotNull(message = "게시판 id는 필수입니다.") @PathVariable Long boardId,
+            @Validated @NotNull(message = "페이지 번호는 필수입니다.") @RequestParam Integer page,
+            @Validated @NotNull(message = "페이지 크기는 필수입니다.") @RequestParam Integer pageSize,
+            @Validated @NotNull(message = "타입은 필수입니다.") @RequestParam PostListType type,
+            @Validated @NotNull(message = "검색어는 필수입니다.") @RequestParam String keyword) {
+        final PostListResponse response = postService.searchByAll(page, pageSize, boardId, type, keyword);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_BY_ALL_SUCCESS, response));
+    }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -42,6 +42,7 @@ public enum ResultCode {
     CREATE_BOARD_SUCCESS(200, "B111", "게시판 추가에 성공하였습니다."),
     DELETE_BOARD_SUCCESS(200, "B112", "게시판 삭제에 성공하였습니다."),
     VIEW_POST_LIST_SUCCESS(200, "B113", "게시판 목록 조회에 성공하였습니다."),
+    SEARCH_BY_WRITER_SUCCESS(200, "B114", "제목 검색에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -44,6 +44,7 @@ public enum ResultCode {
     VIEW_POST_LIST_SUCCESS(200, "B113", "게시판 목록 조회에 성공하였습니다."),
     SEARCH_BY_TITLE_SUCCESS(200, "B114", "제목 검색에 성공하였습니다."),
     SEARCH_BY_WRITER_SUCCESS(200, "B115", "작성자 검색에 성공하였습니다."),
+    SEARCH_BY_ALL_SUCCESS(200, "B116", "제목, 내용 검색에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -43,6 +43,7 @@ public enum ResultCode {
     DELETE_BOARD_SUCCESS(200, "B112", "게시판 삭제에 성공하였습니다."),
     VIEW_POST_LIST_SUCCESS(200, "B113", "게시판 목록 조회에 성공하였습니다."),
     SEARCH_BY_TITLE_SUCCESS(200, "B114", "제목 검색에 성공하였습니다."),
+    SEARCH_BY_WRITER_SUCCESS(200, "B115", "작성자 검색에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -42,7 +42,7 @@ public enum ResultCode {
     CREATE_BOARD_SUCCESS(200, "B111", "게시판 추가에 성공하였습니다."),
     DELETE_BOARD_SUCCESS(200, "B112", "게시판 삭제에 성공하였습니다."),
     VIEW_POST_LIST_SUCCESS(200, "B113", "게시판 목록 조회에 성공하였습니다."),
-    SEARCH_BY_WRITER_SUCCESS(200, "B114", "제목 검색에 성공하였습니다."),
+    SEARCH_BY_TITLE_SUCCESS(200, "B114", "제목 검색에 성공하였습니다."),
 
     // Verification
     REQUEST_VERIFY_SUCCESS(200, "V100", "인증 키 검증 요청에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
@@ -18,4 +18,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(Board board, String title, Pageable pageable);
 
     Page<Post> findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(Board board, String title, Pageable pageable);
+
+    Page<Post> findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescIdDesc(Board board, String writer, Pageable pageable);
+
+    Page<Post> findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(Board board, String writer, Pageable pageable);
+
+    Page<Post> findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(Board board, String writer, Pageable pageable);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
@@ -24,4 +24,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(Board board, String writer, Pageable pageable);
 
     Page<Post> findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(Board board, String writer, Pageable pageable);
+
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescIdDesc(Board board, String title, String content, Pageable pageable);
+
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(Board board, String title, String content, Pageable pageable);
+
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(Board board, String title, String content, Pageable pageable);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
@@ -8,7 +8,14 @@ import wegrus.clubwebsite.entity.post.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByBoardOrderByTypeDescIdDesc(Board board, Pageable pageable);
+
     Page<Post> findByBoardOrderByTypeDescPostLikeNumDescIdDesc(Board board, Pageable pageable);
+
     Page<Post> findByBoardOrderByTypeDescReplyNumDescIdDesc(Board board, Pageable pageable);
 
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescIdDesc(Board board, String title, Pageable pageable);
+
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(Board board, String title, Pageable pageable);
+
+    Page<Post> findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(Board board, String title, Pageable pageable);
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -123,7 +123,7 @@ public class PostService {
                 .map(s -> s.getRole().getName())
                 .collect(Collectors.toList());
 
-        if(roles.contains(MemberRoles.ROLE_BAN.name()) || roles.contains(MemberRoles.ROLE_RESIGN.name()))
+        if (roles.contains(MemberRoles.ROLE_BAN.name()) || roles.contains(MemberRoles.ROLE_RESIGN.name()))
             return new PostResponse(new PostUnknownDto(post), replies);
 
         return new PostResponse(new PostDto(post), replies);
@@ -150,7 +150,7 @@ public class PostService {
 
         postLikeRepository.save(postLike);
 
-        post.likeNum(post.getPostLikeNum()+1);
+        post.likeNum(post.getPostLikeNum() + 1);
 
         return postLike.getId();
     }
@@ -166,7 +166,7 @@ public class PostService {
 
         postLikeRepository.delete(postLike);
 
-        post.likeNum(post.getPostLikeNum()-1);
+        post.likeNum(post.getPostLikeNum() - 1);
     }
 
     @Transactional(readOnly = true)
@@ -197,40 +197,47 @@ public class PostService {
     }
 
     @Transactional
-    public PostListResponse getList(Integer page, Integer pageSize, Long boardId, PostListType type){
+    public PostListResponse getList(Integer page, Integer pageSize, Long boardId, PostListType type) {
         Pageable pageable = PageRequest.of(page, pageSize);
         final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+        Page<Post> posts;
 
-        if(type == PostListType.LASTEST){
-            Page<Post> posts = postRepository.findByBoardOrderByTypeDescIdDesc(board, pageable);
-
-            List<PostListDto> postDtos = posts.stream()
-                    .map(PostListDto::new)
-                    .collect(Collectors.toList());
-
-            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
-        }
-        else if(type == PostListType.LIKEEST){
-            Page<Post> posts = postRepository.findByBoardOrderByTypeDescPostLikeNumDescIdDesc(board, pageable);
-
-            List<PostListDto> postDtos = posts.stream()
-                    .map(PostListDto::new)
-                    .collect(Collectors.toList());
-
-            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
-        }
-        else if(type == PostListType.REPLYEST){
-            Page<Post> posts = postRepository.findByBoardOrderByTypeDescReplyNumDescIdDesc(board, pageable);
-
-            List<PostListDto> postDtos = posts.stream()
-                    .map(PostListDto::new)
-                    .collect(Collectors.toList());
-
-            return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
-        }
-        else{
+        if (type == PostListType.LASTEST)
+            posts = postRepository.findByBoardOrderByTypeDescIdDesc(board, pageable);
+        else if (type == PostListType.LIKEEST)
+            posts = postRepository.findByBoardOrderByTypeDescPostLikeNumDescIdDesc(board, pageable);
+        else if (type == PostListType.REPLYEST)
+            posts = postRepository.findByBoardOrderByTypeDescReplyNumDescIdDesc(board, pageable);
+        else
             throw new PostListTypeNotFoundException();
-        }
+
+        List<PostListDto> postDtos = posts.stream()
+                .map(PostListDto::new)
+                .collect(Collectors.toList());
+
+        return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+    }
+
+    @Transactional
+    public PostListResponse searchByWriter(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+        Page<Post> posts;
+
+        if (type == PostListType.LASTEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescIdDesc(board, keyword, pageable);
+        else if (type == PostListType.LIKEEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(board, keyword, pageable);
+        else if (type == PostListType.REPLYEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(board, keyword, pageable);
+        else
+            throw new PostListTypeNotFoundException();
+
+        List<PostListDto> postDtos = posts.stream()
+                .map(PostListDto::new)
+                .collect(Collectors.toList());
+
+        return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
     }
 
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -219,6 +219,28 @@ public class PostService {
     }
 
     @Transactional
+    public PostListResponse searchByWriter(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+        Page<Post> posts;
+
+        if (type == PostListType.LASTEST)
+            posts = postRepository.findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescIdDesc(board, keyword, pageable);
+        else if (type == PostListType.LIKEEST)
+            posts = postRepository.findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(board, keyword, pageable);
+        else if (type == PostListType.REPLYEST)
+            posts = postRepository.findByBoardAndMemberNameContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(board, keyword, pageable);
+        else
+            throw new PostListTypeNotFoundException();
+
+        List<PostListDto> postDtos = posts.stream()
+                .map(PostListDto::new)
+                .collect(Collectors.toList());
+
+        return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+    }
+
+    @Transactional
     public PostListResponse searchByTitle(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
         Pageable pageable = PageRequest.of(page, pageSize);
         final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -219,7 +219,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostListResponse searchByWriter(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
+    public PostListResponse searchByTitle(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
         Pageable pageable = PageRequest.of(page, pageSize);
         final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         Page<Post> posts;

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -262,4 +262,26 @@ public class PostService {
         return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
     }
 
+    @Transactional
+    public PostListResponse searchByAll(Integer page, Integer pageSize, Long boardId, PostListType type, String keyword) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        final Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+        Page<Post> posts;
+
+        if (type == PostListType.LASTEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescIdDesc(board, keyword, keyword, pageable);
+        else if (type == PostListType.LIKEEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescPostLikeNumDescIdDesc(board, keyword, keyword, pageable);
+        else if (type == PostListType.REPLYEST)
+            posts = postRepository.findByBoardAndTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByTypeDescReplyNumDescIdDesc(board, keyword, keyword, pageable);
+        else
+            throw new PostListTypeNotFoundException();
+
+        List<PostListDto> postDtos = posts.stream()
+                .map(PostListDto::new)
+                .collect(Collectors.toList());
+
+        return new PostListResponse(new PageImpl<>(postDtos, pageable, posts.getTotalElements()));
+    }
+
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #42 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 제목 검색 api 추가
- GET 방식으로 전달받은 키워드가 제목에 포함되어있는 게시물 목록을 반환
- 대소문자 구분 X

### 제목+내용 검색 api 추가
- 전달받은 키워드가 제목, 내용 둘중 하나라도 포함되어있는 게시물 목록을 반환
- 대소문자 구분 X

### 작성자 검색 api 추가
- 전달받은 키워드가 작성자에 포함되어있는 게시물 목록을 반환
- 게시물 전달시에는 학번 + 이름을 작성자이름으로 반환하지만, 검색시에는 이름만 확인
  - ex) 작성자 표시는 19이도경이지만, "19" 키워드로 작성자 검색 시 검색 되지 않음
  - 학번도 검색가능하도록 변경 가능
- 대소문자 구분 X

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
