### PR TITLE
[마이페이지] 게시물 목록 조회 API 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -6,11 +6,7 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.entity.post.BoardCategories;
-import wegrus.clubwebsite.entity.post.BoardCategory;
 import wegrus.clubwebsite.entity.post.Boards;
-import wegrus.clubwebsite.repository.BoardCategoryRepository;
-import wegrus.clubwebsite.repository.BoardRepository;
-import wegrus.clubwebsite.repository.RoleRepository;
 
 import javax.annotation.PostConstruct;
 import java.sql.PreparedStatement;
@@ -22,76 +18,22 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SetupConfig {
 
-    private final RoleRepository roleRepository;
-    private final BoardCategoryRepository boardCategoryRepository;
-    private final BoardRepository boardRepository;
     private final JdbcTemplate jdbcTemplate;
 
     @PostConstruct
     private void setup() {
-        // Roles
-        roleRepository.deleteAllInBatch();
+        initTableRoles();
+        initTableBoardCategories();
+        initTableBoards();
 
-        final List<String> roles = Arrays.stream(MemberRoles.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
+    }
 
-        final String sql = "INSERT INTO ROLES (`role_name`) VALUES(?)";
-        final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
-            @Override
-            public void setValues(PreparedStatement ps, int i) throws SQLException {
-                ps.setString(1, roles.get(i));
-            }
-
-            @Override
-            public int getBatchSize() {
-                return roles.size();
-            }
-        };
-        jdbcTemplate.batchUpdate(sql, pss);
-
-        // Board_Categories
-        boardCategoryRepository.deleteAllInBatch();
-
-        final List<String> boardCategories = Arrays.stream(BoardCategories.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
-
-        final String categorySql = "INSERT INTO BOARD_CATEGORIES (`board_category_name`) VALUES(?)";
-        final BatchPreparedStatementSetter categoryPss = new BatchPreparedStatementSetter() {
-            @Override
-            public void setValues(PreparedStatement ps, int i) throws SQLException {
-                ps.setString(1, boardCategories.get(i));
-            }
-
-            @Override
-            public int getBatchSize() {
-                return boardCategories.size();
-            }
-        };
-        jdbcTemplate.batchUpdate(categorySql, categoryPss);
-
-        // Boards
-        boardRepository.deleteAllInBatch();
-
-        List<Long> boardCategoryIds = boardCategoryRepository.findAll()
-                .stream()
-                .map(BoardCategory::getId)
-                .collect(Collectors.toList());
-
-        List<Long> boardCategoryIdOrders = Arrays.asList(
-                boardCategoryIds.get(0),
-                boardCategoryIds.get(1),
-                boardCategoryIds.get(1),
-                boardCategoryIds.get(1),
-                boardCategoryIds.get(1),
-                boardCategoryIds.get(2),
-                boardCategoryIds.get(3),
-                boardCategoryIds.get(3),
-                boardCategoryIds.get(3),
-                boardCategoryIds.get(3),
-                boardCategoryIds.get(3),
-                boardCategoryIds.get(3)
+    private void initTableBoards() {
+        final List<Long> boardCategoryIdOrders = Arrays.asList(
+                1L,
+                2L, 2L, 2L, 2L,
+                3L,
+                4L, 4L, 4L, 4L, 4L, 4L
         );
 
         final List<String> boards = Arrays.stream(Boards.values())
@@ -113,6 +55,45 @@ public class SetupConfig {
             }
         };
         jdbcTemplate.batchUpdate(boardSql, boardPss);
+    }
 
+    private void initTableBoardCategories() {
+        final List<String> boardCategories = Arrays.stream(BoardCategories.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String categorySql = "INSERT INTO BOARD_CATEGORIES (`board_category_name`) VALUES(?)";
+        final BatchPreparedStatementSetter categoryPss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, boardCategories.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return boardCategories.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(categorySql, categoryPss);
+    }
+
+    private void initTableRoles() {
+        final List<String> roles = Arrays.stream(MemberRoles.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String sql = "INSERT INTO ROLES (`role_name`) VALUES(?)";
+        final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, roles.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return roles.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(sql, pss);
     }
 }

--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -25,7 +25,6 @@ public class SetupConfig {
         initTableRoles();
         initTableBoardCategories();
         initTableBoards();
-
     }
 
     private void initTableBoards() {
@@ -40,7 +39,7 @@ public class SetupConfig {
                 .map(Enum::name)
                 .collect(Collectors.toList());
 
-        final String boardSql = "INSERT INTO BOARDS (`board_category_id`, `board_name`) VALUES(?, ?)";
+        final String boardSql = "INSERT INTO boards (`board_category_id`, `board_name`) VALUES(?, ?)";
         final BatchPreparedStatementSetter boardPss = new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -62,7 +61,7 @@ public class SetupConfig {
                 .map(Enum::name)
                 .collect(Collectors.toList());
 
-        final String categorySql = "INSERT INTO BOARD_CATEGORIES (`board_category_name`) VALUES(?)";
+        final String categorySql = "INSERT INTO board_categories (`board_category_name`) VALUES(?)";
         final BatchPreparedStatementSetter categoryPss = new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -82,7 +81,7 @@ public class SetupConfig {
                 .map(Enum::name)
                 .collect(Collectors.toList());
 
-        final String sql = "INSERT INTO ROLES (`role_name`) VALUES(?)";
+        final String sql = "INSERT INTO roles (`role_name`) VALUES(?)";
         final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,9 @@ import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
+import wegrus.clubwebsite.dto.post.BookmarkDto;
+import wegrus.clubwebsite.dto.post.PostDto;
+import wegrus.clubwebsite.dto.post.PostReplyDto;
 import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.MemberAlreadyBanException;
@@ -207,5 +211,35 @@ public class MemberController {
         final StatusResponse response = memberService.sendRandomCode();
 
         return ResponseEntity.ok(ResultResponse.of(SEND_CERTIFICATION_CODE_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "내가 작성한 게시물 목록 조회")
+    @GetMapping("/members/posts")
+    public ResponseEntity<ResultResponse> getMyPosts(
+            @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "게시물 page당 size는 필수입니다.") @RequestParam int size) {
+        final Page<PostDto> response = memberService.getMyPosts(page, size);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_MY_POSTS_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "내가 작성한 댓글 목록 조회")
+    @GetMapping("/members/replies")
+    public ResponseEntity<ResultResponse> getMyReplies(
+            @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "게시물 page당 size는 필수입니다.") @RequestParam int size) {
+        final Page<PostReplyDto> response = memberService.getMyReplies(page, size);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_MY_REPLIES_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "내가 저장한 게시물 목록 조회")
+    @GetMapping("/members/bookmarks")
+    public ResponseEntity<ResultResponse> getMyBookmarks(
+            @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "게시물 page당 size는 필수입니다.") @RequestParam int size) {
+        final Page<BookmarkDto> response = memberService.getMyBookmarks(page, size);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_MY_BOOKMARKS_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSignupRequest.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.Gender;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
 
@@ -42,7 +43,11 @@ public class MemberSignupRequest {
     @NotNull(message = "회원 학년은 필수입니다.")
     private MemberGrade grade;
 
-    @ApiModelProperty(value = "회원 아이디", example = "kakao_124125124124", required = true)
+    @ApiModelProperty(value = "회원 아이디", example = "kakao_2090341149", required = true)
     @NotBlank(message = "회원 아이디는 필수입니다.")
     private String userId;
+
+    @ApiModelProperty(value = "회원 성별", example = "MAN", required = true)
+    @NotNull(message = "회원 성별은 필수입니다.")
+    private Gender gender;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/BookmarkDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/BookmarkDto.java
@@ -1,0 +1,14 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookmarkDto {
+
+    private Long bookmarkId;
+    private PostDto post;
+}

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -1,10 +1,10 @@
 package wegrus.clubwebsite.dto.post;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wegrus.clubwebsite.entity.post.Post;
 import wegrus.clubwebsite.vo.Image;
-import wegrus.clubwebsite.vo.ImageType;
 
 import java.time.LocalDateTime;
 
@@ -46,5 +46,25 @@ public class PostDto {
         this.postView = post.getViews().size();
         this.postBookmarks = post.getBookmarks().size();
         this.secretFlag = post.isSecretFlag();
+    }
+
+    @QueryProjection
+    public PostDto(Long postId, Long memberId, String memberName, Image image, String board, String boardCategory, String type, String title, String content, LocalDateTime createdDate, LocalDateTime updatedDate, Integer postLike, Integer postReplies, Integer postView, Integer postBookmarks, boolean secretFlag) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.image = image;
+        this.board = board;
+        this.boardCategory = boardCategory;
+        this.type = type;
+        this.title = title;
+        this.content = content;
+        this.createdDate = createdDate;
+        this.updatedDate = updatedDate;
+        this.postLike = postLike;
+        this.postReplies = postReplies;
+        this.postView = postView;
+        this.postBookmarks = postBookmarks;
+        this.secretFlag = secretFlag;
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostReplyDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostReplyDto.java
@@ -1,0 +1,33 @@
+package wegrus.clubwebsite.dto.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.post.Reply;
+import wegrus.clubwebsite.vo.Image;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PostReplyDto {
+
+    private Long replyId;
+    private String content;
+    private Long memberId;
+    private String memberName;
+    private Image memberImage;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+    private PostDto post;
+
+    public PostReplyDto(Reply reply, PostDto post) {
+        this.replyId = reply.getId();
+        this.content = reply.getContent();
+        this.memberId = reply.getMember().getId();
+        this.memberName = reply.getMember().getStudentId().substring(2, 4).concat(reply.getMember().getName());
+        this.memberImage = reply.getMember().getImage();
+        this.createdDate = reply.getCreatedDate();
+        this.updatedDate = reply.getUpdatedDate();
+        this.post = post;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -26,6 +26,9 @@ public enum ResultCode {
     NEED_TO_REJOIN(200, "M115", "탈퇴한 회원입니다. 회원 가입을 먼저 해주세요."),
     BANNED_USER(200, "M116", "강제 탈퇴된 회원입니다."),
     SEND_CERTIFICATION_CODE_SUCCESS(200, "M117", "회원의 이메일로 인증 코드 발송에 성공하였습니다."),
+    GET_MY_POSTS_SUCCESS(200, "M118", "회원이 작성한 게시물 목록 조회에 성공하였습니다."),
+    GET_MY_REPLIES_SUCCESS(200, "M118", "회원이 작성한 댓글 목록 조회에 성공하였습니다."),
+    GET_MY_BOOKMARKS_SUCCESS(200, "M119", "회원이 저장한 게시물 목록 조회에 성공하였습니다."),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/member/Gender.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Gender.java
@@ -1,0 +1,5 @@
+package wegrus.clubwebsite.entity.member;
+
+public enum Gender {
+    MAN, WOMAN
+}

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -80,7 +80,7 @@ public class Member {
     @Column(name = "member_introduce")
     private String introduce = "";
 
-    @Column(name = "memger_gender")
+    @Column(name = "member_gender")
     private Gender gender;
 
     @Embedded

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -80,6 +80,9 @@ public class Member {
     @Column(name = "member_introduce")
     private String introduce = "";
 
+    @Column(name = "memger_gender")
+    private Gender gender;
+
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "url", column = @Column(name = "member_image_url")),
@@ -94,7 +97,7 @@ public class Member {
     private MemberAcademicStatus academicStatus;
 
     @Builder
-    public Member(String userId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus) {
+    public Member(String userId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus, Gender gender) {
         this.userId = userId;
         this.email = email;
         this.name = name;
@@ -104,6 +107,7 @@ public class Member {
         this.phone = phone;
         this.academicStatus = academicStatus;
         this.image = Image.builder().url(MEMBER_BASIC_IMAGE_URL).build();
+        this.gender = gender;
     }
 
     public void update(MemberInfoUpdateRequest request) {
@@ -139,5 +143,6 @@ public class Member {
         this.phone = request.getPhone();
         this.academicStatus = request.getAcademicStatus();
         this.grade = request.getGrade();
+        this.gender = request.getGender();
     }
 }

--- a/src/main/java/wegrus/clubwebsite/entity/post/Bookmark.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/Bookmark.java
@@ -16,7 +16,7 @@ public class Bookmark {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bookmark_id", updatable = false)
-    private Long Id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.post.Board;
 import wegrus.clubwebsite.entity.post.Post;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
     Page<Post> findByBoardOrderByTypeDescIdDesc(Board board, Pageable pageable);
 
     Page<Post> findByBoardOrderByTypeDescPostLikeNumDescIdDesc(Board board, Pageable pageable);

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepositoryQuerydsl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepositoryQuerydsl.java
@@ -1,0 +1,14 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wegrus.clubwebsite.dto.post.BookmarkDto;
+import wegrus.clubwebsite.dto.post.PostDto;
+import wegrus.clubwebsite.dto.post.PostReplyDto;
+
+public interface PostRepositoryQuerydsl {
+
+    Page<PostDto> findPostDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable);
+    Page<BookmarkDto> findBookmarkedPostDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable);
+    Page<PostReplyDto> findPostReplyDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable);
+}

--- a/src/main/java/wegrus/clubwebsite/repository/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostRepositoryQuerydslImpl.java
@@ -1,0 +1,158 @@
+package wegrus.clubwebsite.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import wegrus.clubwebsite.dto.post.*;
+import wegrus.clubwebsite.entity.post.Bookmark;
+import wegrus.clubwebsite.entity.post.Reply;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static wegrus.clubwebsite.entity.member.QMember.member;
+import static wegrus.clubwebsite.entity.post.QBoard.board;
+import static wegrus.clubwebsite.entity.post.QBoardCategory.boardCategory;
+import static wegrus.clubwebsite.entity.post.QBookmark.bookmark;
+import static wegrus.clubwebsite.entity.post.QPost.post;
+import static wegrus.clubwebsite.entity.post.QReply.reply;
+
+@RequiredArgsConstructor
+public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PostDto> findPostDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable) {
+        final List<PostDto> postDtos = queryFactory
+                .select(new QPostDto(
+                        post.id,
+                        post.member.id,
+                        post.member.studentId.substring(2, 4).append(post.member.name),
+                        post.member.image,
+                        post.board.name,
+                        post.board.boardCategory.name,
+                        post.type.stringValue(),
+                        post.title,
+                        post.content,
+                        post.createdDate,
+                        post.updatedDate,
+                        post.postLikeNum,
+                        post.postReplyNum,
+                        post.views.size(),
+                        post.bookmarks.size(),
+                        post.secretFlag
+                ))
+                .from(post)
+                .innerJoin(post.member, member)
+                .innerJoin(post.board, board)
+                .innerJoin(post.board.boardCategory, boardCategory)
+                .where(post.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(post.createdDate.desc())
+                .fetch();
+
+        return new PageImpl<>(postDtos, pageable, postDtos.size());
+    }
+
+    @Override
+    public Page<BookmarkDto> findBookmarkedPostDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable) {
+        final List<Bookmark> bookmarks = queryFactory
+                .selectFrom(bookmark)
+                .innerJoin(bookmark.post, post)
+                .where(bookmark.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(bookmark.id.desc())
+                .fetch();
+        final List<Long> postIds = bookmarks.stream()
+                .map(b -> b.getPost().getId())
+                .collect(Collectors.toList());
+
+        final List<PostDto> postDtos = queryFactory
+                .select(new QPostDto(
+                        post.id,
+                        post.member.id,
+                        post.member.studentId.substring(2, 4).append(post.member.name),
+                        post.member.image,
+                        post.board.name,
+                        post.board.boardCategory.name,
+                        post.type.stringValue(),
+                        post.title,
+                        post.content,
+                        post.createdDate,
+                        post.updatedDate,
+                        post.postLikeNum,
+                        post.postReplyNum,
+                        post.views.size(),
+                        post.bookmarks.size(),
+                        post.secretFlag
+                ))
+                .from(post)
+                .innerJoin(post.member, member)
+                .innerJoin(post.board, board)
+                .innerJoin(post.board.boardCategory, boardCategory)
+                .where(post.id.in(postIds))
+                .fetch();
+        final Map<Long, PostDto> postDtoMap = postDtos.stream()
+                .collect(Collectors.toMap(PostDto::getPostId, p -> p));
+
+        final List<BookmarkDto> bookmarkDtos = bookmarks.stream()
+                .map(b -> new BookmarkDto(b.getId(), postDtoMap.get(b.getPost().getId())))
+                .collect(Collectors.toList());
+        return new PageImpl<>(bookmarkDtos, pageable, bookmarkDtos.size());
+    }
+
+    @Override
+    public Page<PostReplyDto> findPostReplyDtoPageByMemberIdOrderByCreatedDateDesc(Long memberId, Pageable pageable) {
+        final List<Reply> replies = queryFactory
+                .selectFrom(reply)
+                .innerJoin(reply.member, member)
+                .innerJoin(reply.post, post)
+                .where(reply.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(reply.createdDate.desc())
+                .fetch();
+        final List<Long> postIds = replies.stream()
+                .map(r -> r.getPost().getId())
+                .collect(Collectors.toList());
+
+        final List<PostDto> postDtos = queryFactory
+                .select(new QPostDto(
+                        post.id,
+                        post.member.id,
+                        post.member.studentId.substring(2, 4).append(post.member.name),
+                        post.member.image,
+                        post.board.name,
+                        post.board.boardCategory.name,
+                        post.type.stringValue(),
+                        post.title,
+                        post.content,
+                        post.createdDate,
+                        post.updatedDate,
+                        post.postLikeNum,
+                        post.postReplyNum,
+                        post.views.size(),
+                        post.bookmarks.size(),
+                        post.secretFlag
+                ))
+                .from(post)
+                .innerJoin(post.member, member)
+                .innerJoin(post.board, board)
+                .innerJoin(post.board.boardCategory, boardCategory)
+                .where(post.id.in(postIds))
+                .fetch();
+        final Map<Long, PostDto> postDtoMap = postDtos.stream()
+                .collect(Collectors.toMap(PostDto::getPostId, p -> p));
+
+        final List<PostReplyDto> replyDtos = replies.stream()
+                .map(r -> new PostReplyDto(r, postDtoMap.get(r.getPost().getId())))
+                .collect(Collectors.toList());
+        return new PageImpl<>(replyDtos, pageable, replyDtos.size());
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -2,6 +2,9 @@ package wegrus.clubwebsite.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,10 +15,14 @@ import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.member.*;
+import wegrus.clubwebsite.dto.post.BookmarkDto;
+import wegrus.clubwebsite.dto.post.PostDto;
+import wegrus.clubwebsite.dto.post.PostReplyDto;
 import wegrus.clubwebsite.entity.member.MemberRole;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.*;
 import wegrus.clubwebsite.repository.MemberRoleRepository;
+import wegrus.clubwebsite.repository.PostRepository;
 import wegrus.clubwebsite.repository.RoleRepository;
 import wegrus.clubwebsite.util.*;
 import wegrus.clubwebsite.dto.VerificationResponse;
@@ -49,6 +56,7 @@ public class MemberService {
     private final JwtUserDetailsUtil jwtUserDetailsUtil;
     private final AmazonS3Util amazonS3Util;
     private final KakaoUtil kakaoUtil;
+    private final PostRepository postRepository;
 
     @Value("${valid-time.verification-key}")
     private Integer VERIFICATION_KEY_VALID_TIME;
@@ -290,5 +298,29 @@ public class MemberService {
         redisUtil.set(member.getEmail(), String.valueOf(code), 30);
 
         return new StatusResponse(Status.SUCCESS);
+    }
+
+    public Page<PostDto> getMyPosts(int page, int size) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size);
+        return postRepository.findPostDtoPageByMemberIdOrderByCreatedDateDesc(memberId, pageable);
+    }
+
+    public Page<PostReplyDto> getMyReplies(int page, int size){
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size);
+        return postRepository.findPostReplyDtoPageByMemberIdOrderByCreatedDateDesc(memberId, pageable);
+    }
+
+    public Page<BookmarkDto> getMyBookmarks(int page, int size) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size);
+        return postRepository.findBookmarkedPostDtoPageByMemberIdOrderByCreatedDateDesc(memberId, pageable);
     }
 }

--- a/src/test/java/wegrus/clubwebsite/Board/PostRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/Board/PostRepositoryTest.java
@@ -1,10 +1,12 @@
 package wegrus.clubwebsite.Board;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
@@ -18,6 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class PostRepositoryTest {
+
+    @MockBean
+    JPAQueryFactory queryFactory;
 
     @Autowired
     MemberRepository memberRepository;

--- a/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberControllerTest.java
@@ -26,10 +26,7 @@ import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.error.ErrorResponse;
 import wegrus.clubwebsite.dto.member.*;
-import wegrus.clubwebsite.entity.member.Member;
-import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
-import wegrus.clubwebsite.entity.member.MemberGrade;
-import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.entity.member.*;
 import wegrus.clubwebsite.exception.MemberNotFoundException;
 import wegrus.clubwebsite.exception.MemberResignException;
 import wegrus.clubwebsite.service.MemberService;
@@ -155,10 +152,10 @@ public class MemberControllerTest {
     @DisplayName("회원 가입 API: 성공")
     void signup_success() throws Exception {
         // given
-        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN);
         final MemberSignupResponse response = new MemberSignupResponse(new MemberDto(member));
         doReturn(response).when(memberService).validateAndSaveMember(any(MemberSignupRequest.class));
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L");
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L", Gender.MAN);
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -177,9 +174,9 @@ public class MemberControllerTest {
     @DisplayName("회원 가입 API: 바인딩 예외")
     void signup_bindEx() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
-        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
-        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", " ", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token", Gender.MAN);
+        final MemberSignupRequest request2 = new MemberSignupRequest("12161111@gmail.com", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token", Gender.MAN);
+        final MemberSignupRequest request3 = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "01012341234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token", Gender.MAN);
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -227,7 +224,7 @@ public class MemberControllerTest {
     @DisplayName("로그인 API: 성공")
     void login_success() throws Exception {
         // given
-        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN);
         final String accessToken = "accessToken";
         final String refreshToken = "refreshToken";
         final MemberAndJwtDto dto = new MemberAndJwtDto(new MemberDto(member), accessToken, refreshToken);
@@ -414,7 +411,7 @@ public class MemberControllerTest {
     @DisplayName("회원 정보 조회 API: 성공")
     void getInfo_success() throws Exception {
         // given
-        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING);
+        final Member member = new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN);
         final MemberInfoResponse response = new MemberInfoResponse(Status.SUCCESS, new MemberDto(member));
         final MemberInfoResponse response2 = new MemberInfoResponse(Status.SUCCESS, new MemberSimpleDto(member));
         doReturn(response).when(memberService).getMemberInfo(1L);

--- a/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberIntegrationTest.java
@@ -1,6 +1,7 @@
 package wegrus.clubwebsite.member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,7 @@ import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.VerificationResponse;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.result.ResultResponse;
-import wegrus.clubwebsite.entity.member.Member;
-import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
-import wegrus.clubwebsite.entity.member.MemberGrade;
-import wegrus.clubwebsite.entity.member.MemberRoles;
+import wegrus.clubwebsite.entity.member.*;
 import wegrus.clubwebsite.repository.MemberRepository;
 import wegrus.clubwebsite.util.AmazonS3Util;
 import wegrus.clubwebsite.util.KakaoUtil;
@@ -42,6 +40,9 @@ import static wegrus.clubwebsite.dto.result.ResultCode.VERIFY_EMAIL_SUCCESS;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
 public class MemberIntegrationTest {
+
+    @MockBean
+    private JPAQueryFactory queryFactory;
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -81,7 +82,7 @@ public class MemberIntegrationTest {
     }
 
     public MemberSignupResponse signupAPI(String email, String name, String department, String phone, MemberAcademicStatus memberAcademicStatus, MemberGrade memberGrade, String userId) {
-        final MemberSignupRequest memberSignupRequest = new MemberSignupRequest(email, name, department, phone, memberAcademicStatus, memberGrade, userId);
+        final MemberSignupRequest memberSignupRequest = new MemberSignupRequest(email, name, department, phone, memberAcademicStatus, memberGrade, userId, Gender.MAN);
 
         final HttpEntity<MemberSignupRequest> request = new HttpEntity<>(memberSignupRequest);
         final ResponseEntity<ResultResponse> response = restTemplate.postForEntity("/signup", request, ResultResponse.class);

--- a/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRepositoryTest.java
@@ -1,10 +1,12 @@
 package wegrus.clubwebsite.member;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
@@ -15,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class MemberRepositoryTest {
+
+    @MockBean
+    private JPAQueryFactory queryFactory;
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberRoleRepositoryTest.java
@@ -1,10 +1,12 @@
 package wegrus.clubwebsite.member;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import wegrus.clubwebsite.entity.member.*;
@@ -23,6 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class MemberRoleRepositoryTest {
+
+    @MockBean
+    JPAQueryFactory queryFactory;
 
     @Autowired
     private MemberRoleRepository memberRoleRepository;

--- a/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
+++ b/src/test/java/wegrus/clubwebsite/member/MemberServiceTest.java
@@ -123,9 +123,9 @@ public class MemberServiceTest {
     @DisplayName("회원가입: 성공")
     void validateAndSaveMember_success() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token", Gender.MAN);
         doReturn(Optional.empty()).when(memberRepository).findByUserIdOrEmail(any(String.class), any(String.class));
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member.get()).when(memberRepository).save(any(Member.class));
         doReturn(Optional.of(new Role(MemberRoles.ROLE_GUEST.name()))).when(roleRepository).findByName(any(String.class));
         doNothing().when(amazonS3Util).createDirectory(any(String.class));
@@ -141,8 +141,8 @@ public class MemberServiceTest {
     @DisplayName("회원 재가입: 성공")
     void validateAndSaveMember_success2() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L");
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L", Gender.MAN);
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         ReflectionTestUtils.setField(member.get(), "id", 1L);
         doReturn(member).when(memberRepository).findByUserId(any(String.class));
 
@@ -174,8 +174,8 @@ public class MemberServiceTest {
     @DisplayName("회원가입: 실패")
     void validateAndSaveMember_fail() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token");
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "token", Gender.MAN);
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findByUserIdOrEmail(any(String.class), any(String.class));
 
         // when
@@ -190,8 +190,8 @@ public class MemberServiceTest {
     @DisplayName("회원 재가입: 실패")
     void validateAndSaveMember_fail2() throws Exception {
         // given
-        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L");
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final MemberSignupRequest request = new MemberSignupRequest("12161111@inha.edu", "홍길동", "컴퓨터공학과", "010-1234-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "123456789L", Gender.MAN);
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         ReflectionTestUtils.setField(member.get(), "id", 1L);
         doReturn(member).when(memberRepository).findByUserId(any(String.class));
 
@@ -218,7 +218,7 @@ public class MemberServiceTest {
         // given
         doReturn("token").when(kakaoUtil).getAccessTokenFromKakaoAPI(any(String.class));
         doReturn("123456789L").when(kakaoUtil).getUserIdFromKakaoAPI(any(String.class));
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findByUserId(any(String.class));
 
         final Role roleResign = new Role(MemberRoles.ROLE_RESIGN.name());
@@ -312,7 +312,7 @@ public class MemberServiceTest {
     @DisplayName("이메일 검증: 실패")
     void checkEmailAndSendMail_fail() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findByEmail(any(String.class));
 
         // when
@@ -326,9 +326,9 @@ public class MemberServiceTest {
     @DisplayName("회원 정보 조회: 성공")
     void getMemberInfo_success() throws Exception {
         // given
-        final Optional<Member> me = Optional.of(new Member("123456789L", "12161111@inha.edu", "username", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> me = Optional.of(new Member("123456789L", "12161111@inha.edu", "username", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         ReflectionTestUtils.setField(me.get(), "id", 1L);
-        final Optional<Member> someone = Optional.of(new Member("123456789L", "12161111@inha.edu", "asdfasdf", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> someone = Optional.of(new Member("123456789L", "12161111@inha.edu", "asdfasdf", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         ReflectionTestUtils.setField(someone.get(), "id", 2L);
         doReturn(me).when(memberRepository).findById(1L);
         doReturn(someone).when(memberRepository).findById(2L);
@@ -361,7 +361,7 @@ public class MemberServiceTest {
     @DisplayName("회원 정보 수정: 성공")
     void updateMemberInfo_success() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         ReflectionTestUtils.setField(member.get(), "id", 1L);
         final MemberInfoUpdateRequest request = new MemberInfoUpdateRequest("만두", "정통", "010-3333-1234", MemberAcademicStatus.ATTENDING, MemberGrade.SENIOR, "안녕");
         doReturn(member).when(memberRepository).findById(any(Long.class));
@@ -381,7 +381,7 @@ public class MemberServiceTest {
     @DisplayName("회원 이미지 변경: 성공(새 이미지)")
     void updateMemberImage_success() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         member.get().updateImage(Image.builder().url("다른 이미지 url").build());
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
@@ -404,7 +404,7 @@ public class MemberServiceTest {
     @DisplayName("회원 이미지 변경: 성공(기본 이미지)")
     void updateMemberImage_success2() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         member.get().updateImage(Image.builder().url("다른 이미지 url").build());
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
@@ -423,7 +423,7 @@ public class MemberServiceTest {
     @DisplayName("회원 이미지 변경: 실패")
     void updateMemberImage_fail() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         member.get().updateImage(Image.builder().url("구 이미지 저장소 url").build());
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
@@ -474,7 +474,7 @@ public class MemberServiceTest {
         ReflectionTestUtils.setField(role.get(), "id", 1L);
         doReturn(role).when(roleRepository).findByName(any(String.class));
 
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         doReturn(Optional.empty()).when(memberRoleRepository).findByMemberIdAndRoleId(any(Long.class), any(Long.class));
@@ -497,7 +497,7 @@ public class MemberServiceTest {
         ReflectionTestUtils.setField(role.get(), "id", 1L);
         doReturn(role).when(roleRepository).findByName(any(String.class));
 
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         final MemberRole memberRole = new MemberRole(member.get(), role.get());
@@ -514,7 +514,7 @@ public class MemberServiceTest {
     @DisplayName("회원 탈퇴: 성공")
     void resign_success() throws Exception {
         // given
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         final MemberRoles memberRoles = MemberRoles.ROLE_RESIGN;
@@ -570,7 +570,7 @@ public class MemberServiceTest {
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING));
+        final Optional<Member> member = Optional.of(new Member("123456789L", "12161111@inha.edu", "홍길동", "컴퓨터공학과", MemberGrade.SENIOR, "010-1234-1234", MemberAcademicStatus.ATTENDING, Gender.MAN));
         doReturn(member).when(memberRepository).findById(any(Long.class));
 
         final String code = "123123";


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #47 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### [마이페이지] 게시물 목록 조회 API
- join으로 쿼리 최적화(페이징)
- 0페이지 부터 시작하며, 파라미터가 1 이상인 경우 -1 적용하여 페이지 계산
- 추가된 API
    - 내가 쓴 게시물 목록 조회 API 추가
        - 게시물 작성 일자 내림차순 정렬
    - 내가 쓴 댓글 목록 조회 API 추가
        - 댓글 작성 일자 내림차순 정렬
    - 내가 저장한 게시물 목록 조회 API 추가
        - 게시물 저장 일자 내림차순 정렬
- Querydsl은 2-levels reference 속성까지만 초기화
    - 따라서, `bookmark.post.board.boardCategory.name`과 같이 deep-levels을 조회할 때 null값을 받음
    - 레퍼런스에서는 `@QueryInit`을 사용하면 해결된다는데, 해결되지 않음
    - `hibernate.fetch_max_depth` 설정을 하라는 이야기도 있었는데, 해결되지 않음
    - 따라서 쿼리를 두 번으로 나누어서 위 문제 해결 -> 참고: `PostRepositoryQuerydslImpl`
    
## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- 앞으로 모든 테스트는 시간 관계상 Swagger로 진행 -> 테스트 코드는 개발 완료 후 작성할 예정

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- [Querydsl Path initialization](http://querydsl.com/static/querydsl/4.2.1/reference/html/ch03s03.html#d0e2181)

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
