### PR TITLE
그룹 가입 신청 API 추가 등

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtAccessDeniedHandler.java
@@ -14,17 +14,18 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static wegrus.clubwebsite.dto.error.ErrorCode.INSUFFICIENT_AUTHORITY;
+
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
-        response.setStatus(errorCode.getStatus());
+        response.setStatus(INSUFFICIENT_AUTHORITY.getStatus());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         try (OutputStream os = response.getOutputStream()){
             ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(os, ErrorResponse.of(errorCode));
+            objectMapper.writeValue(os, ErrorResponse.of(INSUFFICIENT_AUTHORITY));
             os.flush();
         }
     }

--- a/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
+++ b/src/main/java/wegrus/clubwebsite/config/JwtRequestFilter.java
@@ -54,8 +54,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             request.setAttribute("errorCode", EXPIRED_ACCESS_TOKEN);
         } catch (JwtException e) {
             request.setAttribute("errorCode", INVALID_JWT);
-        } catch (AccessDeniedException e) {
-            request.setAttribute("errorCode", INSUFFICIENT_AUTHORITY);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/SetupConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
+import wegrus.clubwebsite.entity.group.Groups;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.entity.post.BoardCategories;
 import wegrus.clubwebsite.entity.post.Boards;
@@ -25,6 +26,7 @@ public class SetupConfig {
         initTableRoles();
         initTableBoardCategories();
         initTableBoards();
+        initTableGroups();
     }
 
     private void initTableBoards() {
@@ -91,6 +93,26 @@ public class SetupConfig {
             @Override
             public int getBatchSize() {
                 return roles.size();
+            }
+        };
+        jdbcTemplate.batchUpdate(sql, pss);
+    }
+
+    private void initTableGroups() {
+        final List<String> groups = Arrays.stream(Groups.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        final String sql = "INSERT INTO igrus_groups (`group_name`) VALUES(?)";
+        final BatchPreparedStatementSetter pss = new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, groups.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return groups.size();
             }
         };
         jdbcTemplate.batchUpdate(sql, pss);

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(400, "C008", "입력 타입이 유효하지 않습니다."),
     INSUFFICIENT_AUTHORITY(403, "C009", "접근 권한이 부족합니다."),
     MULTIPARTFILE_CONVERT_FAIL(400, "C010", "MultipartFile을 File로 변환하는 데 실패하였습니다."),
+    INVALID_AUTHORIZATION_CODE(400, "C011", "유효하지 않은 인증 코드입니다."),
 
     // Post
     POST_NOT_FOUND(400, "B000", "존재하지 않는 게시물입니다."),
@@ -50,6 +51,10 @@ public enum ErrorCode {
     MEMBER_ALREADY_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
     MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
     CERTIFICATION_CODE_INVALID(400, "M012", "유효하지 않은 인증 코드입니다."),
+
+    // Group
+    GROUP_NOT_FOUND(400, "G000", "존재하지 않는 그룹입니다."),
+    GROUP_MEMBER_ALREADY_EXIST(400, "G001", "이미 해당 그룹에 속한 회원입니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -29,6 +29,7 @@ public enum ResultCode {
     GET_MY_POSTS_SUCCESS(200, "M118", "회원이 작성한 게시물 목록 조회에 성공하였습니다."),
     GET_MY_REPLIES_SUCCESS(200, "M118", "회원이 작성한 댓글 목록 조회에 성공하였습니다."),
     GET_MY_BOOKMARKS_SUCCESS(200, "M119", "회원이 저장한 게시물 목록 조회에 성공하였습니다."),
+    APPLY_TO_GROUP_SUCCESS(200, "M120", "해당 그룹에 성공적으로 가입 신청을 하였습니다."),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/entity/group/Group.java
+++ b/src/main/java/wegrus/clubwebsite/entity/group/Group.java
@@ -1,0 +1,34 @@
+package wegrus.clubwebsite.entity.group;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "igrus_groups")
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
+    private Long id;
+
+    @Column(name = "group_name")
+    private String name;
+
+    @Column(name = "group_create_date")
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    public Group(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/entity/group/GroupMember.java
+++ b/src/main/java/wegrus/clubwebsite/entity/group/GroupMember.java
@@ -1,0 +1,50 @@
+package wegrus.clubwebsite.entity.group;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import wegrus.clubwebsite.entity.member.Member;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "group_members")
+public class GroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "group_member_role")
+    private GroupRoles role;
+
+    @Column(name = "group_member_create_date")
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    public GroupMember(Member member, Group group) {
+        this.member = member;
+        this.group = group;
+        this.role = GroupRoles.APPLICANT;
+    }
+
+    public void updateRole(GroupRoles role){
+        this.role = role;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/entity/group/GroupRoles.java
+++ b/src/main/java/wegrus/clubwebsite/entity/group/GroupRoles.java
@@ -1,0 +1,5 @@
+package wegrus.clubwebsite.entity.group;
+
+public enum GroupRoles {
+    APPLICANT, MEMBER, EXECUTIVE, PRESIDENT
+}

--- a/src/main/java/wegrus/clubwebsite/entity/group/Groups.java
+++ b/src/main/java/wegrus/clubwebsite/entity/group/Groups.java
@@ -1,0 +1,5 @@
+package wegrus.clubwebsite.entity.group;
+
+public enum Groups {
+    IXPLOIT, IGDC, ALGORUS, WEBGRUS
+}

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -96,6 +96,9 @@ public class Member {
     @Column(name = "member_academic_status", nullable = false)
     private MemberAcademicStatus academicStatus;
 
+    @Column(name = "member_refresh_token")
+    private String refreshToken;
+
     @Builder
     public Member(String userId, String email, String name, String department, MemberGrade grade, String phone, MemberAcademicStatus academicStatus, Gender gender) {
         this.userId = userId;
@@ -144,5 +147,9 @@ public class Member {
         this.academicStatus = request.getAcademicStatus();
         this.grade = request.getGrade();
         this.gender = request.getGender();
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/wegrus/clubwebsite/exception/AuthorizationCodeInvalidException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/AuthorizationCodeInvalidException.java
@@ -1,0 +1,12 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class AuthorizationCodeInvalidException extends BusinessException {
+    public AuthorizationCodeInvalidException(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.INVALID_INPUT_VALUE, errors);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/GroupMemberAlreadyExistException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/GroupMemberAlreadyExistException.java
@@ -1,0 +1,9 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class GroupMemberAlreadyExistException extends BusinessException {
+    public GroupMemberAlreadyExistException() {
+        super(ErrorCode.GROUP_MEMBER_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/GroupNotFoundException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/GroupNotFoundException.java
@@ -1,0 +1,9 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class GroupNotFoundException extends BusinessException {
+    public GroupNotFoundException() {
+        super(ErrorCode.GROUP_NOT_FOUND);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/JwtInvalidException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/JwtInvalidException.java
@@ -1,9 +1,12 @@
 package wegrus.clubwebsite.exception;
 
 import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
 
 public class JwtInvalidException extends BusinessException {
-    public JwtInvalidException(){
-        super(ErrorCode.INVALID_JWT);
+    public JwtInvalidException(List<ErrorResponse.FieldError> errors){
+        super(ErrorCode.INVALID_JWT, errors);
     }
 }

--- a/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.group.GroupMember;
+
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    Optional<GroupMember> findByMemberIdAndGroupId(Long memberId, Long groupId);
+}

--- a/src/main/java/wegrus/clubwebsite/repository/GroupRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.group.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
@@ -8,7 +8,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+import wegrus.clubwebsite.exception.AuthorizationCodeInvalidException;
+import wegrus.clubwebsite.exception.JwtInvalidException;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -39,11 +45,20 @@ public class KakaoUtil {
         final String grant_type = "authorization_code";
         final String redirect_url = "http://localhost:3000/oauth/kakao/callback";
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, headers);
-        final ResponseEntity<Map> responseEntity = restTemplate.exchange(
-                url + "?grant_type=" + grant_type + "&client_id=" + KAKAO_CLIENT_REST_API_KEY + "&redirect_url=" + redirect_url + "&code=" + authorizationCode
-                , HttpMethod.POST, requestEntity, Map.class);
-        final Map response = responseEntity.getBody();
-        final String accessToken = (String) response.get("access_token");
-        return accessToken;
+        System.out.println("어디서 멈추냐");
+        final ResponseEntity<Map> responseEntity;
+        try {
+            responseEntity = restTemplate.exchange(
+                    url + "?grant_type=" + grant_type + "&client_id=" + KAKAO_CLIENT_REST_API_KEY + "&redirect_url=" + redirect_url + "&code=" + authorizationCode
+                    , HttpMethod.POST, requestEntity, Map.class);
+            final Map response = responseEntity.getBody();
+            final String accessToken = (String) response.get("access_token");
+
+            return accessToken;
+        } catch(Exception e) {
+            final List<ErrorResponse.FieldError> errors = new ArrayList<>();
+            errors.add(new ErrorResponse.FieldError("authorizationCode", authorizationCode, ErrorCode.INVALID_AUTHORIZATION_CODE.getMessage()));
+            throw new AuthorizationCodeInvalidException(errors);
+        }
     }
 }

--- a/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/KakaoUtil.java
@@ -11,7 +11,6 @@ import org.springframework.web.client.RestTemplate;
 import wegrus.clubwebsite.dto.error.ErrorCode;
 import wegrus.clubwebsite.dto.error.ErrorResponse;
 import wegrus.clubwebsite.exception.AuthorizationCodeInvalidException;
-import wegrus.clubwebsite.exception.JwtInvalidException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +44,6 @@ public class KakaoUtil {
         final String grant_type = "authorization_code";
         final String redirect_url = "http://localhost:3000/oauth/kakao/callback";
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, headers);
-        System.out.println("어디서 멈추냐");
         final ResponseEntity<Map> responseEntity;
         try {
             responseEntity = restTemplate.exchange(


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #51 
- Resolve: #52 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 그룹 가입 신청 API 추가
- 회원을 해당 그룹에 `APPLICANT` 권한으로 추가 -> 목록 조회 시, 이를 이용하여 필터링 조회
- 이미 해당 그룹의 회원인 경우 400 응답
### 재발급 토큰 저장소 변경
- Redis -> DB
- 2주 동안 토큰을 Redis에 저장해야 하며, 로그아웃 API를 호출하지 않는 이상 계속 Redis에 토큰이 쌓이는 문제 발생
- ElastiCache 프리티어 용량을 아끼기 위해 DB에 저장
### 403 예외 처리 로직 수정
- JwtRequestFilter Line.40에서 예외 처리가 동작하여, catch (AccessDeniedException)에 걸리지 않음
    - 따라서, `request.setAttribute(...)` 메소드가 동작하지 않아 JwtAccessDeniedHandler에서 ErrorCode를 받지 못하여 오류 발생
- 어차피 403 에러는 401 에러와 달리 하나의 이유만 존재하므로, JwtAccessDeniedHandler에서 직접 `ErrorCode.INSUFFICIENT_AUTHORITY`에 접근하는 방식으로 변경함
### 카카오 인증 코드 예외 처리 추가
![image](https://user-images.githubusercontent.com/68049320/152974189-951e24c8-1641-4f2e-8773-9f066aa199e0.png)
- kauth api 호출하기 위한 인증 코드는 1회용임 -> 유효하지 않은 인증 코드면 400 응답
### SetupConfig: 메소드 추가
- 테이블 명 소문자로 변경(대문자로 하면 인식을 하지 못하는 문제 발생)
- 현재 존재하는 소모임명을 모두 DB에 저장
### Jwt 토큰 예외 응답 데이터 추가
![image](https://user-images.githubusercontent.com/68049320/152974113-64e41bdf-548a-4cbf-9727-21edafe440f9.png)

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
