### PR TITLE
권한 부여/요청 목록 조회 API 추가 등

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -1,0 +1,34 @@
+package wegrus.clubwebsite.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import wegrus.clubwebsite.dto.StatusResponse;
+import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.service.ClubService;
+
+import javax.validation.constraints.NotNull;
+
+import static wegrus.clubwebsite.dto.result.ResultCode.*;
+
+@Api(tags = "동아리 관리 API")
+@RestController
+@RequestMapping("/club")
+@RequiredArgsConstructor
+public class ClubController {
+
+    private final ClubService clubService;
+
+    @ApiOperation(value = "동아리원 권한 부여")
+    @ApiImplicitParam(name = "requestId", value = "권한 요청 PK", example = "1", required = true)
+    @PostMapping("/executives/authority")
+    public ResponseEntity<ResultResponse> empower(
+            @NotNull(message = "권한 요청 PK는 필수입니다.") @RequestParam Long requestId) {
+        final StatusResponse response = clubService.empower(requestId);
+
+        return ResponseEntity.ok(ResultResponse.of(EMPOWER_MEMBER_SUCCESS, response));
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -2,12 +2,17 @@ package wegrus.clubwebsite.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import wegrus.clubwebsite.dto.StatusResponse;
+import wegrus.clubwebsite.dto.member.RequestDto;
 import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.service.ClubService;
 
 import javax.validation.constraints.NotNull;
@@ -15,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
 
 @Api(tags = "동아리 관리 API")
+@Validated
 @RestController
 @RequestMapping("/club")
 @RequiredArgsConstructor
@@ -30,5 +36,21 @@ public class ClubController {
         final StatusResponse response = clubService.empower(requestId);
 
         return ResponseEntity.ok(ResultResponse.of(EMPOWER_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "동아리원 권한 요청 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "role", value = "권한", example = "ROLE_MEMBER", required = true)
+    })
+    @GetMapping("/executives/requests")
+    public ResponseEntity<ResultResponse> getRequests(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "권한 타입은 필수입니다.") @RequestParam MemberRoles role) {
+        final Page<RequestDto> response = clubService.getRequestDtoPage(page, size, role);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_REQUESTS_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -159,7 +159,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "회원 이미지 변경")
-    @ApiImplicitParam(name = "multipartFile", value = "회원 이미지")
+    @ApiImplicitParam(name = "image", value = "회원 이미지")
     @PatchMapping(value = "/members/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ResultResponse> updateImage(@RequestPart(required = false, name = "image") MultipartFile image) throws IOException {
         final MemberImageUpdateResponse response = memberService.updateMemberImage(image);
@@ -233,7 +233,7 @@ public class MemberController {
         return ResponseEntity.ok(ResultResponse.of(GET_MY_BOOKMARKS_SUCCESS, response));
     }
 
-    @ApiOperation(value = "그룹 가입 신청 API")
+    @ApiOperation(value = "그룹 가입 신청")
     @PostMapping("/members/groups/apply")
     public ResponseEntity<ResultResponse> applyToGroup(
             @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId) {

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -32,6 +32,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 import java.io.IOException;
 
@@ -61,7 +62,7 @@ public class MemberController {
     @ApiOperation(value = "회원 가입", notes = "이메일 검증 API에서 받은 토큰과 함께 요청해주세요.")
     @ApiImplicitParam(name = "Authorization", value = "불필요", example = " ")
     @PostMapping("/signup")
-    public ResponseEntity<ResultResponse> signup(@Validated @RequestBody MemberSignupRequest request) {
+    public ResponseEntity<ResultResponse> signup(@RequestBody MemberSignupRequest request) {
         final MemberSignupResponse response = memberService.validateAndSaveMember(request);
 
         return ResponseEntity.ok(ResultResponse.of(SIGNUP_SUCCESS, response));
@@ -73,8 +74,7 @@ public class MemberController {
             @ApiImplicitParam(name = "authorizationCode", value = "카카오 인증 코드", required = true, example = "ASKDJASIN12231KNsakdasdl1210SSALadk5234")
     })
     @PostMapping("/signin")
-    public ResponseEntity<ResultResponse> signin(
-            @Validated @NotBlank(message = "카카오 인증 코드는 필수입니다.") @RequestParam String authorizationCode,
+    public ResponseEntity<ResultResponse> signin(@NotBlank(message = "카카오 인증 코드는 필수입니다.") @RequestParam String authorizationCode,
             HttpServletResponse httpServletResponse) {
         try {
             final MemberAndJwtDto dto = memberService.findMemberAndGenerateJwt(authorizationCode);
@@ -135,7 +135,7 @@ public class MemberController {
             @ApiImplicitParam(name = "email", value = "이메일", required = true, example = "12161542@inha.edu")
     })
     @PostMapping("/signup/check/email")
-    public ResponseEntity<ResultResponse> checkEmail(@RequestParam String email) throws MessagingException {
+    public ResponseEntity<ResultResponse> checkEmail(@NotBlank(message = "이메일은 필수입니다.") @RequestParam String email) throws MessagingException {
         final EmailCheckResponse response = memberService.checkEmailAndSendMail(email);
 
         return ResponseEntity.ok(ResultResponse.of(CHECK_EMAIL_SUCCESS, response));
@@ -152,7 +152,7 @@ public class MemberController {
 
     @ApiOperation(value = "회원 정보 수정")
     @PatchMapping("/members/info")
-    public ResponseEntity<ResultResponse> updateInfo(@Validated @RequestBody MemberInfoUpdateRequest request) {
+    public ResponseEntity<ResultResponse> updateInfo(@RequestBody MemberInfoUpdateRequest request) {
         final MemberInfoUpdateResponse response = memberService.updateMemberInfo(request);
 
         return ResponseEntity.ok(ResultResponse.of(UPDATE_MEMBER_INFO_SUCCESS, response));
@@ -173,7 +173,7 @@ public class MemberController {
             @ApiImplicitParam(name = "email", value = "이메일", required = true, example = "12161542@inha.edu")
     })
     @GetMapping("/signup/validate/email")
-    public ResponseEntity<ResultResponse> validateEmail(@RequestParam String email) {
+    public ResponseEntity<ResultResponse> validateEmail(@NotBlank(message = "이메일은 필수입니다.") @RequestParam String email) {
         final ValidateEmailResponse response = memberService.validateEmail(email);
 
         return ResponseEntity.ok(ResultResponse.of(VALIDATE_EMAIL_SUCCESS, response));
@@ -188,8 +188,9 @@ public class MemberController {
     }
 
     @ApiOperation(value = "회원 탈퇴")
+    @ApiImplicitParam(name = "certificationCode", value = "인증 코드", example = "123456", required = true)
     @PostMapping("/members/resign")
-    public ResponseEntity<ResultResponse> resign(@RequestParam String certificationCode) {
+    public ResponseEntity<ResultResponse> resign(@Pattern(regexp = "^[0-9]{6}$", message = "6자리 인증 코드를 입력해주세요.") @RequestParam String certificationCode) {
         final StatusResponse response = memberService.resign(certificationCode);
 
         return ResponseEntity.ok(ResultResponse.of(MEMBER_RESIGN_SUCCESS, response));
@@ -204,6 +205,10 @@ public class MemberController {
     }
 
     @ApiOperation(value = "내가 작성한 게시물 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true)
+    })
     @GetMapping("/members/posts")
     public ResponseEntity<ResultResponse> getMyPosts(
             @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
@@ -214,6 +219,10 @@ public class MemberController {
     }
 
     @ApiOperation(value = "내가 작성한 댓글 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true)
+    })
     @GetMapping("/members/replies")
     public ResponseEntity<ResultResponse> getMyReplies(
             @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
@@ -224,6 +233,10 @@ public class MemberController {
     }
 
     @ApiOperation(value = "내가 저장한 게시물 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true)
+    })
     @GetMapping("/members/bookmarks")
     public ResponseEntity<ResultResponse> getMyBookmarks(
             @NotNull(message = "게시물 page는 필수입니다.") @RequestParam int page,
@@ -234,6 +247,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "그룹 가입 신청")
+    @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true)
     @PostMapping("/members/groups/apply")
     public ResponseEntity<ResultResponse> applyToGroup(
             @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId) {

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -42,7 +42,7 @@ public enum ErrorCode {
     USERID_ALREADY_EXIST(400, "M001", "이미 존재하는 아이디입니다."),
     EMAIL_ALREADY_EXIST(400, "M002", "이미 존재하는 이메일입니다."),
     INVALID_EMAIL(400, "M003", "인하대학교 이메일 형식만 가능합니다."),
-    MEMBER_ROLE_NOT_FOUND(400, "M004", "존재하지 않는 회원 등급입니다."),
+    MEMBER_ROLE_NOT_FOUND(400, "M004", "존재하지 않는 회원 권한입니다."),
     MEMBER_IMAGE_ALREADY_BASIC(400, "M005", "회원 이미지가 이미 기본 이미지입니다."),
     EMAIL_CERTIFICATION_TOKEN_INVALID(400, "M006", "이메일 검증 토큰이 유효하지 않습니다."),
     MEMBER_ALREADY_HAS_ROLE(400, "M007", "이미 해당 권한을 가지고 있는 회원입니다."),
@@ -51,6 +51,11 @@ public enum ErrorCode {
     MEMBER_ALREADY_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
     MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
     CERTIFICATION_CODE_INVALID(400, "M012", "유효하지 않은 인증 코드입니다."),
+
+    // Request
+    REQUEST_NOT_FOUND(400, "R000", "존재하지 않는 권한 요청입니다."),
+    CANNOT_REQUEST_AUTHORITY(400, "R001", "요청할 수 없는 권한입니다."),
+    REQUEST_ALREADY_EXIST(400, "R002", "이미 해당 권한을 요청하였습니다."),
 
     // Group
     GROUP_NOT_FOUND(400, "G000", "존재하지 않는 그룹입니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityFailResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityFailResponse.java
@@ -1,0 +1,16 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestAuthorityFailResponse extends RequestAuthorityResponse {
+
+    private String reason;
+
+    public RequestAuthorityFailResponse(String status, String reason) {
+        super.setStatus(status);
+        this.reason = reason;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthorityResponse.java
@@ -3,13 +3,13 @@ package wegrus.clubwebsite.dto.member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import wegrus.clubwebsite.entity.member.MemberRoles;
+import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RequestAuthorityResponse {
 
     private String status;
-    private MemberRoles role;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthoritySuccessResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequestAuthoritySuccessResponse.java
@@ -1,0 +1,17 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.MemberRoles;
+
+@Getter
+@NoArgsConstructor
+public class RequestAuthoritySuccessResponse extends RequestAuthorityResponse {
+
+    private MemberRoles role;
+
+    public RequestAuthoritySuccessResponse(String status, MemberRoles role) {
+        super.setStatus(status);
+        this.role = role;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequestDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequestDto.java
@@ -1,0 +1,24 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.member.Member;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class RequestDto {
+
+    private Long id;
+    private String role;
+    private LocalDateTime requestDate;
+    private MemberDto member;
+
+    public RequestDto(Long id, String role, LocalDateTime requestDate, Member member) {
+        this.id = id;
+        this.role = role;
+        this.requestDate = requestDate;
+        this.member = new MemberDto(member);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -31,6 +31,9 @@ public enum ResultCode {
     GET_MY_BOOKMARKS_SUCCESS(200, "M119", "회원이 저장한 게시물 목록 조회에 성공하였습니다."),
     APPLY_TO_GROUP_SUCCESS(200, "M120", "해당 그룹에 성공적으로 가입 신청을 하였습니다."),
 
+    // Club management
+    EMPOWER_MEMBER_SUCCESS(200, "C100", "권한 부여에 성공하였습니다"),
+
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),
     UPDATE_POST_SUCCESS(200, "B101", "게시물 수정에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -33,6 +33,7 @@ public enum ResultCode {
 
     // Club management
     EMPOWER_MEMBER_SUCCESS(200, "C100", "권한 부여에 성공하였습니다"),
+    GET_REQUESTS_SUCCESS(200, "C101", "권한 요청 목록 조회에 성공하였습니다"),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/exception/CannotRequestAuthorityException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/CannotRequestAuthorityException.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class CannotRequestAuthorityException extends BusinessException {
+
+    public CannotRequestAuthorityException(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.CANNOT_REQUEST_AUTHORITY, errors);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/InsufficientAuthorityException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/InsufficientAuthorityException.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class InsufficientAuthorityException extends BusinessException {
+
+    public InsufficientAuthorityException(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.INSUFFICIENT_AUTHORITY, errors);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/exception/RequestNotFoundException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/RequestNotFoundException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class RequestNotFoundException extends BusinessException{
+
+    public RequestNotFoundException() {
+        super(ErrorCode.REQUEST_NOT_FOUND);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package wegrus.clubwebsite.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import wegrus.clubwebsite.entity.member.Member;
 
@@ -12,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserIdOrEmail(String userId, String email);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByUserId(String userId);
+    @Query("select m from Member m join fetch m.roles r join fetch r.role where m.id = :id")
+    Optional<Member> findWithMemberRolesAndRoleById(@Param("id") Long id);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/RequestRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/RequestRepository.java
@@ -7,7 +7,7 @@ import wegrus.clubwebsite.entity.Request;
 
 import java.util.Optional;
 
-public interface RequestRepository extends JpaRepository<Request, Long> {
+public interface RequestRepository extends JpaRepository<Request, Long>, RequestRepositoryQuerydsl {
     void deleteByMemberIdAndRoleId(Long memberId, Long roleId);
     @Query("select r from Request r join fetch r.role where r.id = :id")
     Optional<Request> findWithRoleById(@Param("id") Long id);

--- a/src/main/java/wegrus/clubwebsite/repository/RequestRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/RequestRepository.java
@@ -1,0 +1,15 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import wegrus.clubwebsite.entity.Request;
+
+import java.util.Optional;
+
+public interface RequestRepository extends JpaRepository<Request, Long> {
+    void deleteByMemberIdAndRoleId(Long memberId, Long roleId);
+    @Query("select r from Request r join fetch r.role where r.id = :id")
+    Optional<Request> findWithRoleById(@Param("id") Long id);
+    Optional<Request> findByMemberIdAndRoleId(Long memberId, Long roleId);
+}

--- a/src/main/java/wegrus/clubwebsite/repository/RequestRepositoryQuerydsl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/RequestRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wegrus.clubwebsite.dto.member.RequestDto;
+import wegrus.clubwebsite.entity.member.MemberRoles;
+
+public interface RequestRepositoryQuerydsl {
+
+    Page<RequestDto> findRequestDtoPageByRole(MemberRoles role, Pageable pageable);
+}

--- a/src/main/java/wegrus/clubwebsite/repository/RequestRepositoryQuerydslImpl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/RequestRepositoryQuerydslImpl.java
@@ -1,0 +1,55 @@
+package wegrus.clubwebsite.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import wegrus.clubwebsite.dto.member.RequestDto;
+import wegrus.clubwebsite.entity.Request;
+import wegrus.clubwebsite.entity.member.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static wegrus.clubwebsite.entity.QRequest.request;
+import static wegrus.clubwebsite.entity.member.QMember.member;
+import static wegrus.clubwebsite.entity.member.QMemberRole.memberRole;
+import static wegrus.clubwebsite.entity.member.QRole.role;
+
+@RequiredArgsConstructor
+public class RequestRepositoryQuerydslImpl implements RequestRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<RequestDto> findRequestDtoPageByRole(MemberRoles memberRoles, Pageable pageable) {
+        final List<Request> requests = queryFactory
+                .selectFrom(request)
+                .innerJoin(request.role, role).fetchJoin()
+                .where(request.role.name.eq(memberRoles.name()))
+                .orderBy(request.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        final List<Long> memberIds = requests.stream()
+                .map(r -> r.getMember().getId())
+                .collect(Collectors.toList());
+
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .where(member.id.in(memberIds))
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .fetch();
+        final Map<Long, List<Member>> memberMap = members.stream()
+                .collect(Collectors.groupingBy(Member::getId));
+
+        final List<RequestDto> requestDtos = requests.stream()
+                .map(r -> new RequestDto(r.getId(), r.getRole().getName(), r.getCreatedDate(), memberMap.get(r.getMember().getId()).get(0)))
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(requestDtos, pageable, requestDtos.size());
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/service/ClubService.java
+++ b/src/main/java/wegrus/clubwebsite/service/ClubService.java
@@ -1,0 +1,86 @@
+package wegrus.clubwebsite.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wegrus.clubwebsite.dto.Status;
+import wegrus.clubwebsite.dto.StatusResponse;
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+import wegrus.clubwebsite.entity.Request;
+import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.entity.member.MemberRole;
+import wegrus.clubwebsite.entity.member.Role;
+import wegrus.clubwebsite.exception.*;
+import wegrus.clubwebsite.repository.MemberRepository;
+import wegrus.clubwebsite.repository.MemberRoleRepository;
+import wegrus.clubwebsite.repository.RequestRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static wegrus.clubwebsite.entity.member.MemberRoles.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClubService {
+
+    private final MemberRepository memberRepository;
+    private final RequestRepository requestRepository;
+    private final MemberRoleRepository memberRoleRepository;
+
+    @Transactional
+    public StatusResponse empower(Long requestId) {
+        final Request request = requestRepository.findWithRoleById(requestId).orElseThrow(RequestNotFoundException::new);
+        final Role role = request.getRole();
+        final Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toSet());
+
+        final Member applicant = memberRepository.findById(request.getMember().getId()).orElseThrow(MemberNotFoundException::new);
+        if (memberRoleRepository.findByMemberIdAndRoleId(applicant.getId(), role.getId()).isPresent())
+            throw new MemberAlreadyHasRoleException();
+
+        addAuthority(request, authorities, role, applicant);
+        return new StatusResponse(Status.SUCCESS);
+    }
+
+    private void addAuthority(Request request, Set<String> authorities, Role role, Member applicant) {
+        if (authorities.contains(ROLE_CLUB_PRESIDENT.name())) {
+            final Set<String> roles = Set.of(ROLE_MEMBER.name(), ROLE_GROUP_PRESIDENT.name(), ROLE_CLUB_EXECUTIVE.name());
+            saveMemberRole(request, role, applicant, roles);
+        } else if (authorities.contains(ROLE_CLUB_EXECUTIVE.name())) {
+            final Set<String> roles = Set.of(ROLE_MEMBER.name(), ROLE_GROUP_PRESIDENT.name());
+            if (request.getRole().getName().equals(ROLE_CLUB_EXECUTIVE.name())) {
+                List<ErrorResponse.FieldError> errors = new ArrayList<>();
+                errors.add(new ErrorResponse.FieldError("authority", ROLE_CLUB_PRESIDENT.name(), "해당 권한이 부족합니다."));
+                throw new InsufficientAuthorityException(errors);
+            }
+            saveMemberRole(request, role, applicant, roles);
+        } else {
+            List<ErrorResponse.FieldError> errors = new ArrayList<>();
+            if (request.getRole().getName().equals(ROLE_CLUB_EXECUTIVE.name())) {
+                errors.add(new ErrorResponse.FieldError("authority", ROLE_CLUB_PRESIDENT.name(), "해당 권한이 부족합니다."));
+            } else {
+                errors.add(new ErrorResponse.FieldError("authority", ROLE_CLUB_EXECUTIVE.name(), "해당 권한이 부족합니다."));
+            }
+            throw new InsufficientAuthorityException(errors);
+        }
+    }
+
+    private void saveMemberRole(Request request, Role role, Member applicant, Set<String> roles) {
+        if (roles.contains(request.getRole().getName())) {
+            requestRepository.deleteByMemberIdAndRoleId(applicant.getId(), role.getId());
+            memberRoleRepository.save(new MemberRole(applicant, role));
+        } else {
+            List<ErrorResponse.FieldError> errors = new ArrayList<>();
+            errors.add(new ErrorResponse.FieldError("role", request.getRole().getName(), ErrorCode.CANNOT_REQUEST_AUTHORITY.getMessage()));
+            throw new CannotRequestAuthorityException(errors);
+        }
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -193,7 +193,7 @@ public class MemberService {
 
     public EmailCheckResponse checkEmailAndSendMail(String email) throws MessagingException {
         if (memberRepository.findByEmail(email).isPresent())
-            return new EmailCheckResponse(Status.FAILURE, EMAIL_ALREADY_EXIST.getMessage()); // TODO: 제거
+            return new EmailCheckResponse(Status.FAILURE, EMAIL_ALREADY_EXIST.getMessage());
         else if (!Pattern.matches("^[0-9]{8}@(inha.edu|inha.ac.kr)$", email))
             return new EmailCheckResponse(Status.FAILURE, INVALID_EMAIL.getMessage());
         final String verificationKey = sendVerificationMail(email);

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -14,10 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.StatusResponse;
+import wegrus.clubwebsite.dto.error.ErrorCode;
 import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.post.BookmarkDto;
 import wegrus.clubwebsite.dto.post.PostDto;
 import wegrus.clubwebsite.dto.post.PostReplyDto;
+import wegrus.clubwebsite.entity.Request;
 import wegrus.clubwebsite.entity.group.Group;
 import wegrus.clubwebsite.entity.group.GroupMember;
 import wegrus.clubwebsite.entity.member.MemberRole;
@@ -39,6 +41,7 @@ import java.util.stream.Collectors;
 
 import static wegrus.clubwebsite.dto.error.ErrorCode.*;
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
+import static wegrus.clubwebsite.entity.member.MemberRoles.*;
 import static wegrus.clubwebsite.util.ImageUtil.MEMBER_BASIC_IMAGE_URL;
 
 @Service
@@ -58,6 +61,7 @@ public class MemberService {
     private final PostRepository postRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final RequestRepository requestRepository;
 
     @Value("${valid-time.verification-key}")
     private Integer VERIFICATION_KEY_VALID_TIME;
@@ -189,7 +193,7 @@ public class MemberService {
 
     public EmailCheckResponse checkEmailAndSendMail(String email) throws MessagingException {
         if (memberRepository.findByEmail(email).isPresent())
-            return new EmailCheckResponse(Status.FAILURE, EMAIL_ALREADY_EXIST.getMessage());
+            return new EmailCheckResponse(Status.FAILURE, EMAIL_ALREADY_EXIST.getMessage()); // TODO: 제거
         else if (!Pattern.matches("^[0-9]{8}@(inha.edu|inha.ac.kr)$", email))
             return new EmailCheckResponse(Status.FAILURE, INVALID_EMAIL.getMessage());
         final String verificationKey = sendVerificationMail(email);
@@ -247,10 +251,22 @@ public class MemberService {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
+        if (requestRepository.findByMemberIdAndRoleId(memberId, role.getId()).isPresent())
+            return new RequestAuthorityFailResponse(Status.FAILURE, REQUEST_ALREADY_EXIST.getMessage());
+
         if (memberRoleRepository.findByMemberIdAndRoleId(memberId, role.getId()).isPresent())
             throw new MemberAlreadyHasRoleException();
-        memberRoleRepository.save(new MemberRole(member, role));
-        return new RequestAuthorityResponse(Status.SUCCESS, memberRoles);
+
+        final Set<MemberRoles> roles = Set.of(ROLE_MEMBER, ROLE_GROUP_PRESIDENT, ROLE_CLUB_EXECUTIVE);
+        if (roles.contains(memberRoles)) {
+            requestRepository.save(new Request(member, role));
+        } else {
+            List<ErrorResponse.FieldError> errors = new ArrayList<>();
+            errors.add(new ErrorResponse.FieldError("role", memberRoles.name(), ErrorCode.CANNOT_REQUEST_AUTHORITY.getMessage()));
+            throw new CannotRequestAuthorityException(errors);
+        }
+
+        return new RequestAuthoritySuccessResponse(Status.SUCCESS, memberRoles);
     }
 
     @Transactional

--- a/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/JwtUserDetailsUtil.java
@@ -26,7 +26,7 @@ public class JwtUserDetailsUtil implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String id) {
-        Member findMember = memberRepository.findById(Long.valueOf(id)).orElseThrow(MemberNotFoundException::new);
+        Member findMember = memberRepository.findWithMemberRolesAndRoleById(Long.valueOf(id)).orElseThrow(MemberNotFoundException::new);
 
         List<GrantedAuthority> authorities = new ArrayList<>();
         for (MemberRole role : findMember.getRoles())


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #58 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### JwtUserDetailsUtil.loadUserByUsername() 메소드 쿼리 개선
- MemberRoles, Role fetch join으로 한 번에 조회
### 동아리원 권한 부여 API 추가
- 동아리 임원: 동아리원, 그룹 회장 부여 가능
- 동아리 회장: 동아리원, 그룹 회장, 동아리 임원 부여 가능
### 동아리원 권한 요청 목록 조회 API 추가
- 페이징, 권한 타입(`ROLE_MEMBER, ROLE_GROUP_PRESIDENT, ROLE_CLUB_EXECUTIVE`)에 따라 조회 가능
- fetch join level 한계로 쿼리를 두 번으로 나누어 실행 + fetch join 쿼리 최적화
### 권한 요청 API 로직 수정
- 요청 후, 권한 부여 API 호출을 통해 권한 획득 가능
- 중복 요청 방지 로직 추가

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- 로직이 수정되면서 기존 테스트 코드도 일일이 수정해야 하는데, 시간 관계상 생략
- Swagger, 프론트와의 협업을 통해 테스트를 진행하고, 개발 완료 후에 모든 테스트 코드 점검&작성 

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
