### PR TITLE
회원 검색/목록 조회 API 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
+++ b/src/main/java/wegrus/clubwebsite/config/WebSecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 import static org.springframework.web.cors.CorsConfiguration.ALL;
+import static wegrus.clubwebsite.entity.member.MemberRoles.*;
 
 @Configuration
 @EnableWebSecurity
@@ -67,9 +68,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/", "/swagger-resources/**", "/swagger-ui/**", "/signup/**", "/signin", "/reissue").permitAll()
-                .antMatchers("/members/**").hasAuthority("ROLE_GUEST")
-                .antMatchers("/posts/**", "/comments/**").hasAuthority("ROLE_MEMBER")
-                .antMatchers("/club/executives/**").hasAuthority("ROLE_CLUB_EXECUTIVE")
+                .antMatchers("/members/**").hasAuthority(ROLE_MEMBER.name())
+                .antMatchers("/posts/**", "/comments/**").hasAuthority(ROLE_MEMBER.name())
+                .antMatchers("/club/executives/**").hasAnyAuthority(ROLE_CLUB_EXECUTIVE.name(), ROLE_CLUB_PRESIDENT.name())
                 .anyRequest().authenticated()
                 .and()
 

--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -6,15 +6,20 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import wegrus.clubwebsite.dto.member.MemberSearchType;
 import wegrus.clubwebsite.dto.StatusResponse;
+import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberSortType;
 import wegrus.clubwebsite.dto.member.RequestDto;
 import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.service.ClubService;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -52,5 +57,45 @@ public class ClubController {
         final Page<RequestDto> response = clubService.getRequestDtoPage(page, size, role);
 
         return ResponseEntity.ok(ResultResponse.of(GET_REQUESTS_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "type", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true)
+    })
+    @GetMapping("/executives/members")
+    public ResponseEntity<ResultResponse> getMembers(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType type,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction) {
+        final Page<MemberDto> response = clubService.getMemberDtoPage(page, size, type, direction);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_MEMBERS_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(검색어)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "searchType", value = "검색 타입", example = "DEPARTMENT", required = true),
+            @ApiImplicitParam(name = "word", value = "검색어", example = "컴퓨터공학과", required = true)
+    })
+    @GetMapping("/executives/search")
+    public ResponseEntity<ResultResponse> searchMembers(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "검색 타입은 필수입니다.") @RequestParam MemberSearchType searchType,
+            @NotBlank(message = "검색어는 필수입니다.") @RequestParam String word) {
+        final Page<MemberDto> response = clubService.searchMember(page, size, sortType, direction, searchType, word);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSearchType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSearchType.java
@@ -1,0 +1,17 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberSearchType {
+    NAME("member_name"),
+    STUDENT_ID("member_student_id"),
+    DEPARTMENT("member_department"),
+    PHONE("member_phone");
+
+    private final String field;
+
+    MemberSearchType(String field) {
+        this.field = field;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSortType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSortType.java
@@ -1,0 +1,21 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberSortType {
+    ID("member_id"),
+    NAME("member_name"),
+    STUDENT_ID("member_student_id"),
+    DEPARTMENT("member_department"),
+    PHONE("member_phone"),
+    GENDER("member_gender"),
+    ACADEMIC_STATUS("member_academic_status"),
+    GRADE("member_grade");
+
+    private final String field;
+
+    MemberSortType(String field) {
+        this.field = field;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -34,6 +34,8 @@ public enum ResultCode {
     // Club management
     EMPOWER_MEMBER_SUCCESS(200, "C100", "권한 부여에 성공하였습니다"),
     GET_REQUESTS_SUCCESS(200, "C101", "권한 요청 목록 조회에 성공하였습니다"),
+    GET_MEMBERS_SUCCESS(200, "C102", "회원 목록 조회에 성공하였습니다"),
+    SEARCH_MEMBER_SUCCESS(200, "C103", "회원 검색에 성공하였습니다"),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepository.java
@@ -9,11 +9,14 @@ import wegrus.clubwebsite.entity.member.Member;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryQuerydsl {
 
     Optional<Member> findByUserIdOrEmail(String userId, String email);
+
     Optional<Member> findByEmail(String email);
+
     Optional<Member> findByUserId(String userId);
+
     @Query("select m from Member m join fetch m.roles r join fetch r.role where m.id = :id")
     Optional<Member> findWithMemberRolesAndRoleById(@Param("id") Long id);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberSearchType;
+
+public interface MemberRepositoryQuerydsl {
+
+    Page<MemberDto> findMemberDtoPage(Pageable pageable);
+
+    Page<MemberDto> findMemberDtoPageByWordContainingAtSearchType(Pageable pageable, MemberSearchType searchType, String word);
+}

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
@@ -1,0 +1,105 @@
+package wegrus.clubwebsite.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberSearchType;
+import wegrus.clubwebsite.entity.member.Member;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static wegrus.clubwebsite.entity.member.QMember.member;
+import static wegrus.clubwebsite.entity.member.QMemberRole.memberRole;
+import static wegrus.clubwebsite.entity.member.QRole.role;
+
+@RequiredArgsConstructor
+public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MemberDto> findMemberDtoPage(Pageable pageable) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByWordContainingAtSearchType(Pageable pageable, MemberSearchType searchType, String word) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(search(searchType, word))
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    private BooleanExpression search(MemberSearchType searchType, String word) {
+        switch (searchType.getField()) {
+            case "member_name":
+                return member.name.contains(word);
+            case "member_student_id":
+                return member.studentId.contains(word);
+            case "member_department":
+                return member.department.contains(word);
+            case "member_phone":
+                return member.phone.contains(word);
+        }
+        return null;
+    }
+
+    private OrderSpecifier<?> memberSort(Pageable pageable) {
+        for (Sort.Order order : pageable.getSort()) {
+            final Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            switch (order.getProperty()) {
+                case "member_id":
+                    return new OrderSpecifier<>(direction, member.id);
+                case "member_name":
+                    return new OrderSpecifier<>(direction, member.name);
+                case "member_student_id":
+                    return new OrderSpecifier<>(direction, member.studentId);
+                case "member_department":
+                    return new OrderSpecifier<>(direction, member.department);
+                case "member_phone":
+                    return new OrderSpecifier<>(direction, member.phone);
+                case "member_gender":
+                    return new OrderSpecifier<>(direction, member.gender);
+                case "member_academic_status":
+                    return new OrderSpecifier<>(direction, member.academicStatus);
+                case "member_grade":
+                    return new OrderSpecifier<>(direction, member.grade);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/wegrus/clubwebsite/service/ClubService.java
+++ b/src/main/java/wegrus/clubwebsite/service/ClubService.java
@@ -1,9 +1,7 @@
 package wegrus.clubwebsite.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -11,6 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.error.ErrorResponse;
+import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberSearchType;
+import wegrus.clubwebsite.dto.member.MemberSortType;
 import wegrus.clubwebsite.dto.member.RequestDto;
 import wegrus.clubwebsite.entity.Request;
 import wegrus.clubwebsite.entity.member.Member;
@@ -67,14 +68,6 @@ public class ClubService {
                 throw new InsufficientAuthorityException(errors);
             }
             saveMemberRole(request, role, applicant, roles);
-        } else {
-            List<ErrorResponse.FieldError> errors = new ArrayList<>();
-            if (request.getRole().getName().equals(ROLE_CLUB_EXECUTIVE.name())) {
-                errors.add(new ErrorResponse.FieldError("authority", ROLE_CLUB_PRESIDENT.name(), "해당 권한이 부족합니다."));
-            } else {
-                errors.add(new ErrorResponse.FieldError("authority", ROLE_CLUB_EXECUTIVE.name(), "해당 권한이 부족합니다."));
-            }
-            throw new InsufficientAuthorityException(errors);
         }
     }
 
@@ -100,5 +93,17 @@ public class ClubService {
         page = (page == 0 ? 0 : page - 1);
         Pageable pageable = PageRequest.of(page, size);
         return requestRepository.findRequestDtoPageByRole(role, pageable);
+    }
+
+    public Page<MemberDto> getMemberDtoPage(int page, int size, MemberSortType type, Sort.Direction direction) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, type.getField()));
+        return memberRepository.findMemberDtoPage(pageable);
+    }
+
+    public Page<MemberDto> searchMember(int page, int size, MemberSortType sortType, Sort.Direction direction, MemberSearchType searchType, String word) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByWordContainingAtSearchType(pageable, searchType, word);
     }
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #60 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 검색 API 추가
- 페이징
- 검색 타입: 학과, 학번, 이름, 연락처 -> 사용자가 임의로 입력하는 값이므로 `contains`로 조회
- 정렬 타입: 가입 순(default), 각 속성별 이름(내림차순, 오름차순)
### 회원 목록 조회 API 추가
- 페이징
- 정렬 타입: 가입 순(default), 각 속성별 이름(내림차순, 오름차순)

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- (성별, 학적 상태, 학년, 권한) 으로 검색하는 API는 따로 만들 예정입니다. #62 
    - 위의 속성들은 정해진 값 중에 하나를 선택하는 값이기 때문에, `equal` 으로 조회하는 방식으로 구현하려 합니다.

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
