### PR TITLE
회원 검색(타입별), 그룹 목록 조회 API 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -10,12 +10,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import wegrus.clubwebsite.dto.member.MemberSearchType;
+import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.dto.StatusResponse;
-import wegrus.clubwebsite.dto.member.MemberDto;
-import wegrus.clubwebsite.dto.member.MemberSortType;
-import wegrus.clubwebsite.dto.member.RequestDto;
 import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.entity.member.Gender;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.service.ClubService;
 
@@ -86,8 +86,8 @@ public class ClubController {
             @ApiImplicitParam(name = "searchType", value = "검색 타입", example = "DEPARTMENT", required = true),
             @ApiImplicitParam(name = "word", value = "검색어", example = "컴퓨터공학과", required = true)
     })
-    @GetMapping("/executives/search")
-    public ResponseEntity<ResultResponse> searchMembers(
+    @GetMapping("/executives/members/search")
+    public ResponseEntity<ResultResponse> searchMember(
             @NotNull(message = "page는 필수입니다.") @RequestParam int page,
             @NotNull(message = "size는 필수입니다.") @RequestParam int size,
             @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
@@ -95,6 +95,106 @@ public class ClubController {
             @NotNull(message = "검색 타입은 필수입니다.") @RequestParam MemberSearchType searchType,
             @NotBlank(message = "검색어는 필수입니다.") @RequestParam String word) {
         final Page<MemberDto> response = clubService.searchMember(page, size, sortType, direction, searchType, word);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(성별)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "gender", value = "회원 성별", example = "MAN", required = true)
+    })
+    @GetMapping("/executives/members/genders")
+    public ResponseEntity<ResultResponse> searchMembersByGender(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 성별은 필수입니다.") @RequestParam Gender gender) {
+        final Page<MemberDto> response = clubService.searchMemberByGender(page, size, sortType, direction, gender);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(학적 상태)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "academicStatus", value = "회원 학적 상태", example = "ATTENDING", required = true)
+    })
+    @GetMapping("/executives/members/academic-statuses")
+    public ResponseEntity<ResultResponse> searchMembersByAcademicStatus(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 학적 상태는 필수입니다.") @RequestParam MemberAcademicStatus academicStatus) {
+        final Page<MemberDto> response = clubService.searchMemberByAcademicStatus(page, size, sortType, direction, academicStatus);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(학년)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "grade", value = "회원 학년", example = "SENIOR", required = true)
+    })
+    @GetMapping("/executives/members/grades")
+    public ResponseEntity<ResultResponse> searchMembersByAcademicStatus(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 학년은 필수입니다.") @RequestParam MemberGrade grade) {
+        final Page<MemberDto> response = clubService.searchMemberByGrade(page, size, sortType, direction, grade);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(권한)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "authority", value = "회원 권한", example = "MEMBER", required = true)
+    })
+    @GetMapping("/executives/members/authorities")
+    public ResponseEntity<ResultResponse> searchMembersByAuthority(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 학년은 필수입니다.") @RequestParam MemberRoleSearchType authority) {
+        final Page<MemberDto> response = clubService.searchMembersByAuthority(page, size, sortType, direction, authority);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(그룹)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true)
+    })
+    @GetMapping("/executives/members/groups")
+    public ResponseEntity<ResultResponse> searchMembersByGroup(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId) {
+        final Page<MemberDto> response = clubService.searchMembersByGroup(page, size, sortType, direction, groupId);
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/MemberController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/MemberController.java
@@ -20,6 +20,7 @@ import wegrus.clubwebsite.dto.post.BookmarkDto;
 import wegrus.clubwebsite.dto.post.PostDto;
 import wegrus.clubwebsite.dto.post.PostReplyDto;
 import wegrus.clubwebsite.dto.result.ResultResponse;
+import wegrus.clubwebsite.entity.group.Group;
 import wegrus.clubwebsite.entity.member.MemberRoles;
 import wegrus.clubwebsite.exception.MemberAlreadyBanException;
 import wegrus.clubwebsite.exception.MemberAlreadyResignException;
@@ -35,6 +36,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import java.io.IOException;
+import java.util.List;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
 
@@ -254,5 +256,13 @@ public class MemberController {
         final StatusResponse response = memberService.applyToGroup(groupId);
 
         return ResponseEntity.ok(ResultResponse.of(APPLY_TO_GROUP_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "그룹 목록 조회")
+    @GetMapping("/members/groups")
+    public ResponseEntity<ResultResponse> getGroups() {
+        final List<Group> response = memberService.getGroups();
+
+        return ResponseEntity.ok(ResultResponse.of(GET_GROUPS_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/GroupDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/GroupDto.java
@@ -1,0 +1,31 @@
+package wegrus.clubwebsite.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.entity.group.GroupRoles;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GroupDto {
+
+    private Long id;
+    private String name;
+    private GroupRoles role;
+    private LocalDateTime joinDate;
+
+    @JsonIgnore
+    private Long memberId;
+
+    @QueryProjection
+    public GroupDto(Long id, String name, GroupRoles role, LocalDateTime joinDate, Long memberId) {
+        this.id = id;
+        this.name = name;
+        this.role = role;
+        this.joinDate = joinDate;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberDto.java
@@ -2,6 +2,7 @@ package wegrus.clubwebsite.dto.member;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
 import wegrus.clubwebsite.entity.member.MemberGrade;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class MemberDto {
 
@@ -26,6 +28,7 @@ public class MemberDto {
     private String imageUrl;
     private MemberAcademicStatus academicStatus;
     private List<String> roles = new ArrayList<>();
+    private List<GroupDto> groups = new ArrayList<>();
 
     public MemberDto(Member member) {
         this.id = member.getId();

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberRoleSearchType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberRoleSearchType.java
@@ -1,0 +1,18 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberRoleSearchType {
+    ALL("ROLE_GUEST"),
+    MEMBER("ROLE_MEMBER"),
+    EXECUTIVE("ROLE_CLUB_EXECUTIVE"),
+    PRESIDENT("ROLE_CLUB_PRESIDENT")
+    ;
+
+    private final String roleName;
+
+    MemberRoleSearchType(String roleName) {
+        this.roleName = roleName;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberSimpleDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberSimpleDto.java
@@ -2,6 +2,7 @@ package wegrus.clubwebsite.dto.member;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import wegrus.clubwebsite.entity.member.Member;
 import wegrus.clubwebsite.entity.member.MemberGrade;
 
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class MemberSimpleDto {
 
@@ -21,6 +23,7 @@ public class MemberSimpleDto {
     private String introduce;
     private String imageUrl;
     private List<String> roles = new ArrayList<>();
+    private List<GroupDto> groups = new ArrayList<>();
 
     public MemberSimpleDto(Member member) {
         this.name = member.getName();

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -30,6 +30,7 @@ public enum ResultCode {
     GET_MY_REPLIES_SUCCESS(200, "M118", "회원이 작성한 댓글 목록 조회에 성공하였습니다."),
     GET_MY_BOOKMARKS_SUCCESS(200, "M119", "회원이 저장한 게시물 목록 조회에 성공하였습니다."),
     APPLY_TO_GROUP_SUCCESS(200, "M120", "해당 그룹에 성공적으로 가입 신청을 하였습니다."),
+    GET_GROUPS_SUCCESS(200, "M121", "그룹 목록 조회에 성공하였습니다."),
 
     // Club management
     EMPOWER_MEMBER_SUCCESS(200, "C100", "권한 부여에 성공하였습니다"),

--- a/src/main/java/wegrus/clubwebsite/entity/group/Group.java
+++ b/src/main/java/wegrus/clubwebsite/entity/group/Group.java
@@ -3,16 +3,13 @@ package wegrus.clubwebsite.entity.group;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "igrus_groups")
 public class Group {
 
@@ -23,10 +20,6 @@ public class Group {
 
     @Column(name = "group_name")
     private String name;
-
-    @Column(name = "group_create_date")
-    @CreatedDate
-    private LocalDateTime createdDate;
 
     public Group(String name) {
         this.name = name;

--- a/src/main/java/wegrus/clubwebsite/entity/member/Member.java
+++ b/src/main/java/wegrus/clubwebsite/entity/member/Member.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import wegrus.clubwebsite.dto.member.MemberInfoUpdateRequest;
 import wegrus.clubwebsite.dto.member.MemberSignupRequest;
+import wegrus.clubwebsite.entity.group.GroupMember;
 import wegrus.clubwebsite.entity.post.*;
 import wegrus.clubwebsite.vo.Image;
 
@@ -46,6 +47,9 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Bookmark> bookmarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private Set<GroupMember> groups = new LinkedHashSet<>();
 
     @Column(name = "member_user_id", unique = true, nullable = false)
     private String userId;

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
@@ -3,11 +3,32 @@ package wegrus.clubwebsite.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberRoleSearchType;
 import wegrus.clubwebsite.dto.member.MemberSearchType;
+import wegrus.clubwebsite.dto.member.MemberSimpleDto;
+import wegrus.clubwebsite.entity.member.Gender;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
+
+import java.util.Optional;
 
 public interface MemberRepositoryQuerydsl {
+
+    Optional<MemberDto> findMemberDtoById(Long id);
+
+    Optional<MemberSimpleDto> findMemberSimpleDtoById(Long id);
 
     Page<MemberDto> findMemberDtoPage(Pageable pageable);
 
     Page<MemberDto> findMemberDtoPageByWordContainingAtSearchType(Pageable pageable, MemberSearchType searchType, String word);
+
+    Page<MemberDto> findMemberDtoPageByGender(Pageable pageable, Gender gender);
+
+    Page<MemberDto> findMemberDtoPageByAcademicStatus(Pageable pageable, MemberAcademicStatus academicStatus);
+
+    Page<MemberDto> findMemberDtoPageByGrade(Pageable pageable, MemberGrade grade);
+
+    Page<MemberDto> findMemberDtoPageByAuthority(Pageable pageable, MemberRoleSearchType authority);
+
+    Page<MemberDto> findMemberDtoPageByGroup(Pageable pageable, Long groupId);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import wegrus.clubwebsite.dto.member.*;
-import wegrus.clubwebsite.entity.group.QGroupMember;
 import wegrus.clubwebsite.entity.member.*;
 
 import java.util.List;

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydslImpl.java
@@ -3,19 +3,23 @@ package wegrus.clubwebsite.repository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import wegrus.clubwebsite.dto.member.MemberDto;
-import wegrus.clubwebsite.dto.member.MemberSearchType;
-import wegrus.clubwebsite.entity.member.Member;
+import wegrus.clubwebsite.dto.member.*;
+import wegrus.clubwebsite.entity.group.QGroupMember;
+import wegrus.clubwebsite.entity.member.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static wegrus.clubwebsite.entity.group.QGroupMember.groupMember;
 import static wegrus.clubwebsite.entity.member.QMember.member;
 import static wegrus.clubwebsite.entity.member.QMemberRole.memberRole;
 import static wegrus.clubwebsite.entity.member.QRole.role;
@@ -24,6 +28,70 @@ import static wegrus.clubwebsite.entity.member.QRole.role;
 public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberDto> findMemberDtoById(Long id) {
+        final Member member = queryFactory
+                .selectFrom(QMember.member)
+                .innerJoin(QMember.member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(QMember.member.id.eq(id))
+                .fetchOne();
+
+        if (member == null)
+            return Optional.empty();
+
+        final List<GroupDto> groupDtos = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(member.getId()))
+                .innerJoin(groupMember.group)
+                .fetch();
+
+        final MemberDto memberDto = new MemberDto(member);
+        if (!groupDtos.isEmpty())
+            memberDto.setGroups(groupDtos);
+
+        return Optional.of(memberDto);
+    }
+
+    @Override
+    public Optional<MemberSimpleDto> findMemberSimpleDtoById(Long id) {
+        final Member member = queryFactory
+                .selectFrom(QMember.member)
+                .innerJoin(QMember.member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(QMember.member.id.eq(id))
+                .fetchOne();
+
+        if (member == null)
+            return Optional.empty();
+
+        final List<GroupDto> groupDtos = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(member.getId()))
+                .innerJoin(groupMember.group)
+                .fetch();
+
+        final MemberSimpleDto memberSimpleDto = new MemberSimpleDto(member);
+        if (!groupDtos.isEmpty())
+            memberSimpleDto.setGroups(groupDtos);
+
+        return Optional.of(memberSimpleDto);
+    }
 
     @Override
     public Page<MemberDto> findMemberDtoPage(Pageable pageable) {
@@ -36,9 +104,32 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
         final List<MemberDto> memberDtos = members.stream()
                 .map(MemberDto::new)
                 .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
 
         return new PageImpl<>(memberDtos, pageable, memberDtos.size());
     }
@@ -55,9 +146,266 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
         final List<MemberDto> memberDtos = members.stream()
                 .map(MemberDto::new)
                 .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByGender(Pageable pageable, Gender gender) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(member.gender.eq(gender))
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByAcademicStatus(Pageable pageable, MemberAcademicStatus academicStatus) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(member.academicStatus.eq(academicStatus))
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByGrade(Pageable pageable, MemberGrade grade) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(member.grade.eq(grade))
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByAuthority(Pageable pageable, MemberRoleSearchType authority) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(
+                        JPAExpressions
+                                .selectFrom(memberRole)
+                                .where(memberRole.member.eq(member).and(memberRole.role.name.eq(authority.getRoleName())))
+                                .exists()
+                )
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final List<MemberRole> memberRoles = queryFactory
+                .selectFrom(memberRole)
+                .innerJoin(memberRole.member, member).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(memberRole.member.id.in(memberIds))
+                .fetch();
+        final Map<Long, List<MemberRole>> memberRoleMap = memberRoles.stream()
+                .collect(Collectors.groupingBy(m -> m.getMember().getId()));
+
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
+        memberDtos.forEach(
+                m -> m.setRoles(memberRoleMap.get(m.getId()).stream()
+                        .map(mr -> mr.getRole().getName())
+                        .collect(Collectors.toList()))
+        );
+
+        return new PageImpl<>(memberDtos, pageable, memberDtos.size());
+    }
+
+    @Override
+    public Page<MemberDto> findMemberDtoPageByGroup(Pageable pageable, Long groupId) {
+        final List<Member> members = queryFactory
+                .selectFrom(member)
+                .innerJoin(member.roles, memberRole).fetchJoin()
+                .innerJoin(memberRole.role, role).fetchJoin()
+                .where(
+                        JPAExpressions
+                                .selectFrom(groupMember)
+                                .where(groupMember.group.id.eq(groupId).and(groupMember.member.eq(member)))
+                                .exists()
+                )
+                .orderBy(memberSort(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final List<Long> memberIds = members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+        final Map<Long, List<GroupDto>> groupDtoMap = queryFactory
+                .select(new QGroupDto(
+                        groupMember.group.id,
+                        groupMember.group.name,
+                        groupMember.role,
+                        groupMember.createdDate,
+                        groupMember.member.id
+                ))
+                .from(groupMember)
+                .where(groupMember.member.id.in(memberIds))
+                .innerJoin(groupMember.group)
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(GroupDto::getMemberId));
+
+        final List<MemberDto> memberDtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        memberDtos.forEach(m -> {
+                    if (groupDtoMap.get(m.getId()) != null)
+                        m.setGroups(groupDtoMap.get(m.getId()));
+                }
+        );
 
         return new PageImpl<>(memberDtos, pageable, memberDtos.size());
     }
@@ -73,6 +421,7 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
             case "member_phone":
                 return member.phone.contains(word);
         }
+
         return null;
     }
 

--- a/src/main/java/wegrus/clubwebsite/service/ClubService.java
+++ b/src/main/java/wegrus/clubwebsite/service/ClubService.java
@@ -9,15 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 import wegrus.clubwebsite.dto.Status;
 import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.error.ErrorResponse;
-import wegrus.clubwebsite.dto.member.MemberDto;
-import wegrus.clubwebsite.dto.member.MemberSearchType;
-import wegrus.clubwebsite.dto.member.MemberSortType;
-import wegrus.clubwebsite.dto.member.RequestDto;
+import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.Request;
-import wegrus.clubwebsite.entity.member.Member;
-import wegrus.clubwebsite.entity.member.MemberRole;
-import wegrus.clubwebsite.entity.member.MemberRoles;
-import wegrus.clubwebsite.entity.member.Role;
+import wegrus.clubwebsite.entity.member.*;
 import wegrus.clubwebsite.exception.*;
 import wegrus.clubwebsite.repository.MemberRepository;
 import wegrus.clubwebsite.repository.MemberRoleRepository;
@@ -105,5 +99,35 @@ public class ClubService {
         page = (page == 0 ? 0 : page - 1);
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
         return memberRepository.findMemberDtoPageByWordContainingAtSearchType(pageable, searchType, word);
+    }
+
+    public Page<MemberDto> searchMemberByGender(int page, int size, MemberSortType sortType, Sort.Direction direction, Gender gender) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByGender(pageable, gender);
+    }
+
+    public Page<MemberDto> searchMemberByAcademicStatus(int page, int size, MemberSortType sortType, Sort.Direction direction, MemberAcademicStatus academicStatus) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByAcademicStatus(pageable, academicStatus);
+    }
+
+    public Page<MemberDto> searchMemberByGrade(int page, int size, MemberSortType sortType, Sort.Direction direction, MemberGrade grade) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByGrade(pageable, grade);
+    }
+
+    public Page<MemberDto> searchMembersByAuthority(int page, int size, MemberSortType sortType, Sort.Direction direction, MemberRoleSearchType authority) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByAuthority(pageable, authority);
+    }
+
+    public Page<MemberDto> searchMembersByGroup(int page, int size, MemberSortType sortType, Sort.Direction direction, Long groupId) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
+        return memberRepository.findMemberDtoPageByGroup(pageable, groupId);
     }
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #62 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 검색(타입별) API 추가
- 회원 검색(성별)
- 회원 검색(학적 상태)
- 회원 검색(학년)
- 회원 검색(권한)
    - 전체, 동아리원, 동아리 임원, 동아리 회장
- 회원 검색(그룹)
    - 해당 그룹원 전체
### MemberDto 필드에 GroupDto 추가
- 회원 정보(MemberDto)에 해당 회원이 가입한 그룹 정보도 추가
### 그룹 목록 조회 API 추가
- 그룹 목록이 필요한 페이지에서 미리 호출해 놓고, 사용
> ex) 회원 검색 API를 호출하는 페이지에 유저가 들어오면, 그룹 목록 조회 API를 미리 호출해 놓고, 회원 검색(그룹) API 호출 시에 사용

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
