### PR TITLE
회원 권한 해제, 회원 강제 탈퇴 API 추가 등

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -33,7 +33,7 @@ public class ClubController {
 
     private final ClubService clubService;
 
-    @ApiOperation(value = "동아리원 권한 부여")
+    @ApiOperation(value = "회원 권한 부여")
     @ApiImplicitParam(name = "requestId", value = "권한 요청 PK", example = "1", required = true)
     @PostMapping("/executives/authority")
     public ResponseEntity<ResultResponse> empower(
@@ -43,7 +43,7 @@ public class ClubController {
         return ResponseEntity.ok(ResultResponse.of(EMPOWER_MEMBER_SUCCESS, response));
     }
 
-    @ApiOperation(value = "동아리원 권한 요청 목록 조회")
+    @ApiOperation(value = "회원 권한 요청 목록 조회")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
             @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
@@ -173,7 +173,7 @@ public class ClubController {
             @NotNull(message = "size는 필수입니다.") @RequestParam int size,
             @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
             @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
-            @NotNull(message = "회원 학년은 필수입니다.") @RequestParam MemberRoleSearchType authority) {
+            @NotNull(message = "회원 권한은 필수입니다.") @RequestParam MemberRoleSearchType authority) {
         final Page<MemberDto> response = clubService.searchMembersByAuthority(page, size, sortType, direction, authority);
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
@@ -197,5 +197,28 @@ public class ClubController {
         final Page<MemberDto> response = clubService.searchMembersByGroup(page, size, sortType, direction, groupId);
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+    
+    @ApiOperation(value = "회원 권한 해제")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "memberId", value = "회원 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "type", value = "회원 권한", example = "ROLE_MEMBER", required = true)
+    })
+    @DeleteMapping("/president/authority")
+    public ResponseEntity<ResultResponse> deleteAuthority(
+            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId,
+            @NotNull(message = "회원 권한은 필수입니다.") @RequestParam MemberRoleDeleteType type) {
+        final StatusResponse response = clubService.deleteAuthority(memberId, type);
+
+        return ResponseEntity.ok(ResultResponse.of(DELETE_AUTHORITY_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 강제 탈퇴(재가입 불가)")
+    @ApiImplicitParam(name = "memberId", value = "회원 PK", example = "1", required = true)
+    @PatchMapping("/president/ban")
+    public ResponseEntity<ResultResponse> banMember(@NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
+        final StatusResponse response = clubService.banMember(memberId);
+
+        return ResponseEntity.ok(ResultResponse.of(BAN_MEMBER_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     MEMBER_ALREADY_RESIGN(400, "M010", "이미 탈퇴한 회원은 회원 탈퇴를 할 수 없습니다."),
     MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
     CERTIFICATION_CODE_INVALID(400, "M012", "유효하지 않은 인증 코드입니다."),
+    GROUP_PRESIDENT_CANNOT_RESIGN(400, "M013", "그룹 회장은 회원 탈퇴를 할 수 없습니다."),
 
     // Request
     REQUEST_NOT_FOUND(400, "R000", "존재하지 않는 권한 요청입니다."),
@@ -60,6 +61,9 @@ public enum ErrorCode {
     // Group
     GROUP_NOT_FOUND(400, "G000", "존재하지 않는 그룹입니다."),
     GROUP_MEMBER_ALREADY_EXIST(400, "G001", "이미 해당 그룹에 속한 회원입니다."),
+
+    // Club management
+    CANNOT_BAN_MEMBER(400, "CM000", "강제 탈퇴시킬 수 없는 회원입니다."),
 
     // File
     NOT_SUPPORTED_IMAGE_TYPE(400, "F000", "이미지 타입은 JPG, PNG, GIF만 지원합니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberRoleDeleteType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberRoleDeleteType.java
@@ -1,0 +1,5 @@
+package wegrus.clubwebsite.dto.member;
+
+public enum MemberRoleDeleteType {
+    ROLE_MEMBER, ROLE_CLUB_EXECUTIVE
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -33,10 +33,12 @@ public enum ResultCode {
     GET_GROUPS_SUCCESS(200, "M121", "그룹 목록 조회에 성공하였습니다."),
 
     // Club management
-    EMPOWER_MEMBER_SUCCESS(200, "C100", "권한 부여에 성공하였습니다"),
-    GET_REQUESTS_SUCCESS(200, "C101", "권한 요청 목록 조회에 성공하였습니다"),
-    GET_MEMBERS_SUCCESS(200, "C102", "회원 목록 조회에 성공하였습니다"),
-    SEARCH_MEMBER_SUCCESS(200, "C103", "회원 검색에 성공하였습니다"),
+    EMPOWER_MEMBER_SUCCESS(200, "CM100", "회원 권한 부여에 성공하였습니다"),
+    GET_REQUESTS_SUCCESS(200, "CM101", "회원 권한 요청 목록 조회에 성공하였습니다"),
+    GET_MEMBERS_SUCCESS(200, "CM102", "회원 목록 조회에 성공하였습니다"),
+    SEARCH_MEMBER_SUCCESS(200, "CM103", "회원 검색에 성공하였습니다"),
+    DELETE_AUTHORITY_SUCCESS(200, "CM104", "회원 권한 해제에 성공하였습니다"),
+    BAN_MEMBER_SUCCESS(200, "CM105", "회원 강제 탈퇴에 성공하였습니다"),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/exception/CannotBanMember.java
+++ b/src/main/java/wegrus/clubwebsite/exception/CannotBanMember.java
@@ -1,0 +1,13 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+import wegrus.clubwebsite.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class CannotBanMember extends BusinessException {
+
+    public CannotBanMember(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.CANNOT_BAN_MEMBER, errors);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
@@ -3,8 +3,14 @@ package wegrus.clubwebsite.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.group.GroupMember;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
     Optional<GroupMember> findByMemberIdAndGroupId(Long memberId, Long groupId);
+
+    void deleteAllByMemberId(Long memberId);
+
+    List<GroupMember> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRoleRepository.java
@@ -1,12 +1,21 @@
 package wegrus.clubwebsite.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import wegrus.clubwebsite.entity.member.MemberRole;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+
     Optional<MemberRole> findByMemberIdAndRoleId(Long memberId, Long roleId);
+
     List<MemberRole> findAllByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
+
+    @Query("select mr from MemberRole mr join fetch mr.role where mr.member.id = :memberId")
+    List<MemberRole> findAllWithRoleByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/wegrus/clubwebsite/service/ClubService.java
+++ b/src/main/java/wegrus/clubwebsite/service/ClubService.java
@@ -13,13 +13,9 @@ import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.Request;
 import wegrus.clubwebsite.entity.member.*;
 import wegrus.clubwebsite.exception.*;
-import wegrus.clubwebsite.repository.MemberRepository;
-import wegrus.clubwebsite.repository.MemberRoleRepository;
-import wegrus.clubwebsite.repository.RequestRepository;
+import wegrus.clubwebsite.repository.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static wegrus.clubwebsite.dto.error.ErrorCode.*;
@@ -33,6 +29,8 @@ public class ClubService {
     private final MemberRepository memberRepository;
     private final RequestRepository requestRepository;
     private final MemberRoleRepository memberRoleRepository;
+    private final RoleRepository roleRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Transactional
     public StatusResponse empower(Long requestId) {
@@ -129,5 +127,49 @@ public class ClubService {
         page = (page == 0 ? 0 : page - 1);
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortType.getField()));
         return memberRepository.findMemberDtoPageByGroup(pageable, groupId);
+    }
+
+    @Transactional
+    public StatusResponse deleteAuthority(Long memberId, MemberRoleDeleteType type) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        final Role role = roleRepository.findByName(type.name()).orElseThrow(MemberRoleNotFoundException::new);
+        final Optional<MemberRole> memberRole = memberRoleRepository.findByMemberIdAndRoleId(member.getId(), role.getId());
+
+        if (memberRole.isEmpty())
+            throw new MemberRoleNotFoundException();
+        memberRoleRepository.delete(memberRole.get());
+
+        return new StatusResponse(Status.SUCCESS);
+    }
+
+    @Transactional
+    public StatusResponse banMember(Long memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        final List<MemberRole> memberRoles = memberRoleRepository.findAllWithRoleByMemberId(member.getId());
+        validateMemberRole(memberRoles);
+
+        final Role role = roleRepository.findByName(ROLE_BAN.name()).orElseThrow(MemberRoleNotFoundException::new);
+        final MemberRole memberRole = new MemberRole(member, role);
+
+        groupMemberRepository.deleteAllByMemberId(member.getId());
+        memberRoleRepository.deleteAllByMemberId(member.getId());
+        memberRoleRepository.save(memberRole);
+        member.resign();
+
+        return new StatusResponse(Status.SUCCESS);
+    }
+
+    private void validateMemberRole(List<MemberRole> memberRoles) {
+        final List<ErrorResponse.FieldError> errors = new ArrayList<>();
+        memberRoles.forEach(mr -> {
+            if (mr.getRole().getName().equals(ROLE_BAN.name()))
+                errors.add(new ErrorResponse.FieldError("role", ROLE_BAN.name(), MEMBER_ALREADY_BAN.getMessage()));
+            else if (mr.getRole().getName().equals(ROLE_RESIGN.name()))
+                errors.add(new ErrorResponse.FieldError("role", ROLE_RESIGN.name(), MEMBER_ALREADY_RESIGN.getMessage()));
+            else if (mr.getRole().getName().equals(ROLE_CLUB_PRESIDENT.name()))
+                errors.add(new ErrorResponse.FieldError("role", ROLE_CLUB_PRESIDENT.name(), CLUB_PRESIDENT_CANNOT_RESIGN.getMessage()));
+        });
+        if (!errors.isEmpty())
+            throw new CannotBanMember(errors);
     }
 }


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

-Resolve: #65

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 회원 권한 해제 API 추가
- 동아리원, 동아리 임원만 해제 가능
### 회원 강제 탈퇴 API 추가
- 이미 탈퇴한 회원, 동아리 회장은 강제 탈퇴 불가능
- 그룹 회장을 탈퇴시키는 경우, 이후 그룹장 새로 임명 필요
### 회원 탈퇴 API 로직 추가
- 회원이 가입한 모든 그룹 탈퇴
- 그룹 회장은 탈퇴 불가능 -> 회장 위임 선행 필요

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
