### PR TITLE
그룹원 검색 API 추가 등

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/ClubController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/ClubController.java
@@ -205,7 +205,25 @@ public class ClubController {
 
         return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
     }
-    
+
+    @ApiOperation(value = "동아리 가입 신청 회원 검색(이름, 학번)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "type", value = "검색 타입", example = "STUDENT_ID", required = true),
+            @ApiImplicitParam(name = "word", value = "검색어", example = "12221234", required = true)
+    })
+    @GetMapping("/executives/requests/search")
+    public ResponseEntity<ResultResponse> searchRequester(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "검색 타입은 필수입니다.") @RequestParam RequesterSearchType type,
+            @NotBlank(message = "검색어는 필수입니다.") @RequestParam String word) {
+        final Page<MemberDto> response = clubService.searchRequester(page, size, type, word);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_MEMBER_SUCCESS, response));
+    }
+
     @ApiOperation(value = "회원 권한 해제")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "memberId", value = "회원 PK", example = "1", required = true),
@@ -252,11 +270,25 @@ public class ClubController {
             @ApiImplicitParam(name = "type", value = "회원 권한", example = "ROLE_MEMBER", required = true)
     })
     @PostMapping("/president/empower")
-    public ResponseEntity<ResultResponse> empower(
+    public ResponseEntity<ResultResponse> empowerMember(
             @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId,
             @NotNull(message = "회원 권한은 필수입니다.") @RequestParam MemberEmpowerType type) {
-        final StatusResponse response = clubService.empower(memberId, type);
+        final StatusResponse response = clubService.empowerMember(memberId, type);
 
         return ResponseEntity.ok(ResultResponse.of(EMPOWER_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "그룹 회장 권한 부여")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "memberId", value = "회원 PK", example = "1", required = true)
+    })
+    @PostMapping("/executives/groups")
+    public ResponseEntity<ResultResponse> empowerGroupPresident(
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId,
+            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
+        final StatusResponse response = clubService.empowerGroupPresident(groupId, memberId);
+
+        return ResponseEntity.ok(ResultResponse.of(EMPOWER_GROUP_PRESIDENT_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/controller/GroupController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/GroupController.java
@@ -12,11 +12,17 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import wegrus.clubwebsite.dto.StatusResponse;
 import wegrus.clubwebsite.dto.member.MemberDto;
+import wegrus.clubwebsite.dto.member.MemberRoleSearchType;
+import wegrus.clubwebsite.dto.member.MemberSearchType;
 import wegrus.clubwebsite.dto.member.MemberSortType;
 import wegrus.clubwebsite.dto.result.ResultResponse;
 import wegrus.clubwebsite.entity.group.GroupRoles;
+import wegrus.clubwebsite.entity.member.Gender;
+import wegrus.clubwebsite.entity.member.MemberAcademicStatus;
+import wegrus.clubwebsite.entity.member.MemberGrade;
 import wegrus.clubwebsite.service.GroupService;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
@@ -57,7 +63,7 @@ public class GroupController {
 
         return ResponseEntity.ok(ResultResponse.of(REJECT_APPLICANT_SUCCESS, response));
     }
-    
+
     @ApiOperation(value = "그룹 임원 권한 부여")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
@@ -134,5 +140,95 @@ public class GroupController {
         final Page<MemberDto> response = groupService.getMemberDtoPage(groupId, role, page, size, type, direction);
 
         return ResponseEntity.ok(ResultResponse.of(GET_GROUP_MEMBERS_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "그룹원 검색(검색어)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "searchType", value = "검색 타입", example = "DEPARTMENT", required = true),
+            @ApiImplicitParam(name = "word", value = "검색어", example = "컴퓨터공학과", required = true)
+    })
+    @GetMapping("/executives/members/search")
+    public ResponseEntity<ResultResponse> searchMember(
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId,
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "검색 타입은 필수입니다.") @RequestParam MemberSearchType searchType,
+            @NotBlank(message = "검색어는 필수입니다.") @RequestParam String word) {
+        final Page<MemberDto> response = groupService.searchMember(groupId, page, size, sortType, direction, searchType, word);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_GROUP_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(성별)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "gender", value = "회원 성별", example = "MAN", required = true)
+    })
+    @GetMapping("/executives/members/genders")
+    public ResponseEntity<ResultResponse> searchMembersByGender(
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId,
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 성별은 필수입니다.") @RequestParam Gender gender) {
+        final Page<MemberDto> response = groupService.searchMemberByGender(groupId, page, size, sortType, direction, gender);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_GROUP_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(학적 상태)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "academicStatus", value = "회원 학적 상태", example = "ATTENDING", required = true)
+    })
+    @GetMapping("/executives/members/academic-statuses")
+    public ResponseEntity<ResultResponse> searchMembersByAcademicStatus(
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId,
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 학적 상태는 필수입니다.") @RequestParam MemberAcademicStatus academicStatus) {
+        final Page<MemberDto> response = groupService.searchMemberByAcademicStatus(groupId, page, size, sortType, direction, academicStatus);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_GROUP_MEMBER_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "회원 검색(학년)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "그룹 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true),
+            @ApiImplicitParam(name = "sortType", value = "정렬 타입", example = "ID", required = true),
+            @ApiImplicitParam(name = "direction", value = "정렬 방향", example = "ASC", required = true),
+            @ApiImplicitParam(name = "grade", value = "회원 학년", example = "SENIOR", required = true)
+    })
+    @GetMapping("/executives/members/grades")
+    public ResponseEntity<ResultResponse> searchMembersByAcademicStatus(
+            @NotNull(message = "그룹 PK는 필수입니다.") @RequestParam Long groupId,
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size,
+            @NotNull(message = "정렬 타입은 필수입니다.") @RequestParam MemberSortType sortType,
+            @NotNull(message = "정렬 방향은 필수입니다.") @RequestParam Sort.Direction direction,
+            @NotNull(message = "회원 학년은 필수입니다.") @RequestParam MemberGrade grade) {
+        final Page<MemberDto> response = groupService.searchMemberByGrade(groupId, page, size, sortType, direction, grade);
+
+        return ResponseEntity.ok(ResultResponse.of(SEARCH_GROUP_MEMBER_SUCCESS, response));
     }
 }

--- a/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/error/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     MEMBER_ALREADY_BAN(400, "M011", "이미 재가입 불가인 회원 탈퇴를 할 수 없습니다."),
     CERTIFICATION_CODE_INVALID(400, "M012", "유효하지 않은 인증 코드입니다."),
     GROUP_PRESIDENT_CANNOT_RESIGN(400, "M013", "그룹 회장은 회원 탈퇴를 할 수 없습니다."),
+    MEMBER_ALREADY_APPLY_GROUP(400, "M013", "이미 해당 그룹에 가입신청을 한 회원입니다."),
 
     // Request
     REQUEST_NOT_FOUND(400, "R000", "존재하지 않는 권한 요청입니다."),

--- a/src/main/java/wegrus/clubwebsite/dto/member/MemberEmpowerType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/MemberEmpowerType.java
@@ -1,5 +1,5 @@
 package wegrus.clubwebsite.dto.member;
 
 public enum MemberEmpowerType {
-    ROLE_MEMBER, ROLE_CLUB_EXECUTIVE, ROLE_GROUP_PRESIDENT
+    ROLE_MEMBER, ROLE_CLUB_EXECUTIVE
 }

--- a/src/main/java/wegrus/clubwebsite/dto/member/RequesterSearchType.java
+++ b/src/main/java/wegrus/clubwebsite/dto/member/RequesterSearchType.java
@@ -1,0 +1,15 @@
+package wegrus.clubwebsite.dto.member;
+
+import lombok.Getter;
+
+@Getter
+public enum RequesterSearchType {
+    NAME("member_name"),
+    STUDENT_ID("member_student_id");
+
+    private final String field;
+
+    RequesterSearchType(String field) {
+        this.field = field;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
+++ b/src/main/java/wegrus/clubwebsite/dto/result/ResultCode.java
@@ -43,6 +43,7 @@ public enum ResultCode {
     RESET_AUTHORITIES_SUCCESS(200, "CM107", "전체 동아리원 권한 초기화에 성공하였습니다."),
     REJECT_AUTHORITY_REQUEST_SUCCESS(200, "CM108", "회원 권한 요청 거절에 성공하였습니다."),
     EMPOWER_MEMBER_SUCCESS(200, "CM109", "회원 권한 부여에 성공하였습니다."),
+    EMPOWER_GROUP_PRESIDENT_SUCCESS(200, "CM110", "그룹 회장 권한 부여에 성공하였습니다."),
 
     // Group management
     GET_GROUP_MEMBERS_SUCCESS(200, "GM100", "그룹원 목록 조회에 성공하였습니다."),
@@ -51,6 +52,7 @@ public enum ResultCode {
     PROMOTE_MEMBER_SUCCESS(200, "GM103", "그룹 임원 권한 부여에 성공하였습니다."),
     DEGRADE_MEMBER_SUCCESS(200, "GM104", "그룹 임원 권한 해제에 성공하였습니다."),
     KICK_GROUP_MEMBER_SUCCESS(200, "GM105", "그룹원 강제 탈퇴에 성공하였습니다."),
+    SEARCH_GROUP_MEMBER_SUCCESS(200, "GM106", "그룹원 검색에 성공하였습니다."),
 
     // Post
     CREATE_POST_SUCCESS(200, "B100", "게시물 등록에 성공하였습니다."),

--- a/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyApplyGroupException.java
+++ b/src/main/java/wegrus/clubwebsite/exception/MemberAlreadyApplyGroupException.java
@@ -1,0 +1,10 @@
+package wegrus.clubwebsite.exception;
+
+import wegrus.clubwebsite.dto.error.ErrorCode;
+
+public class MemberAlreadyApplyGroupException extends BusinessException {
+
+    public MemberAlreadyApplyGroupException() {
+        super(ErrorCode.MEMBER_ALREADY_APPLY_GROUP);
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/GroupMemberRepository.java
@@ -2,6 +2,7 @@ package wegrus.clubwebsite.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.group.GroupMember;
+import wegrus.clubwebsite.entity.group.GroupRoles;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +14,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     void deleteAllByMemberId(Long memberId);
 
     List<GroupMember> findAllByMemberId(Long memberId);
+
+    Optional<GroupMember> findByMemberIdAndRole(Long targetId, GroupRoles role);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/wegrus/clubwebsite/repository/MemberRepositoryQuerydsl.java
@@ -2,10 +2,7 @@ package wegrus.clubwebsite.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import wegrus.clubwebsite.dto.member.MemberDto;
-import wegrus.clubwebsite.dto.member.MemberRoleSearchType;
-import wegrus.clubwebsite.dto.member.MemberSearchType;
-import wegrus.clubwebsite.dto.member.MemberSimpleDto;
+import wegrus.clubwebsite.dto.member.*;
 import wegrus.clubwebsite.entity.group.Group;
 import wegrus.clubwebsite.entity.group.GroupRoles;
 import wegrus.clubwebsite.entity.member.Gender;
@@ -35,4 +32,14 @@ public interface MemberRepositoryQuerydsl {
     Page<MemberDto> findMemberDtoPageByGroup(Pageable pageable, Long groupId);
 
     Page<MemberDto> findMemberDtoPageByGroupAndRole(Pageable pageable, Group group, GroupRoles applicant);
+
+    Page<MemberDto> findMemberDtoPageByWordContainingAtRequesterSearchType(Pageable pageable, RequesterSearchType type, String word);
+
+    Page<MemberDto> findMemberDtoPageByWordContainingAtSearchTypeAndGroup(Pageable pageable, Group group, MemberSearchType searchType, String word);
+
+    Page<MemberDto> findMemberDtoPageByGenderAndGroup(Pageable pageable, Group group, Gender gender);
+
+    Page<MemberDto> findMemberDtoPageByAcademicStatusAndGroup(Pageable pageable, Group group, MemberAcademicStatus academicStatus);
+
+    Page<MemberDto> findMemberDtoPageByGradeAndGroup(Pageable pageable, Group group, MemberGrade grade);
 }

--- a/src/main/java/wegrus/clubwebsite/service/MemberService.java
+++ b/src/main/java/wegrus/clubwebsite/service/MemberService.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 
 import static wegrus.clubwebsite.dto.error.ErrorCode.*;
 import static wegrus.clubwebsite.dto.result.ResultCode.*;
+import static wegrus.clubwebsite.entity.group.GroupRoles.*;
 import static wegrus.clubwebsite.entity.member.MemberRoles.*;
 import static wegrus.clubwebsite.util.ImageUtil.MEMBER_BASIC_IMAGE_URL;
 
@@ -356,8 +357,12 @@ public class MemberService {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         final Group group = groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
-        if (groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId).isPresent())
+        final Optional<GroupMember> findGroupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId);
+        if (findGroupMember.isPresent()) {
+            if (findGroupMember.get().getRole().equals(APPLICANT))
+                throw new MemberAlreadyApplyGroupException();
             throw new GroupMemberAlreadyExistException();
+        }
 
         final GroupMember groupMember = new GroupMember(member, group);
         groupMemberRepository.save(groupMember);


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve: #86 
- Resolve: #87

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### 그룹원 검색 API 추가
- 검색어, 성별, 학적, 상태, 학년
- 권한 검색은 기존의 그룹원 목록 조회 API를 사용
### 회원 권한 부여 API 로직 수정
- 그룹원, 그룹 임원 권한만 부여 가능
- 그룹장은 따로 API를 추가하여 부여할 수 있도록 수정
### 그룹 회장 권한 부여 API 추가
- 동아리 임원, 회장만 API 호출 가능
### 그룹 가입 신청 API 예외 처리 추가
- 가입 신청 중복 방지
### 그룹 권한 부여/해제 시, 제대로 회원 권한 부여/해제가 되지 않는 문제 해결
- 임원 권한을 해제하는 경우, 해당 그룹에서의 역할을 MEMBER로 다운그레이드하며, ROLE_GROUP_EXECUTIVE 또한 해제
    - 만약, 다른 그룹의 임원이 존재한다면 ROLE_GROUP_EXECUTIVE 권한은 해제하지 않음
- 그룹 회장도 위와 같음

## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- comment 1

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- reference 1

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
