### PR TITLE
게시물 등록/조회 api 파일 기능 추가

### DIFF
--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -38,10 +38,11 @@ public class PostController {
     }
 
     @ApiOperation(value = "게시물 등록")
-    @PostMapping("/posts")
-    public ResponseEntity<ResultResponse> createPost(@Validated @RequestBody PostCreateRequest request) {
-        final Long postId = postService.create(request);
-        final PostCreateResponse response = new PostCreateResponse(postId);
+    @PostMapping(value = "/posts")
+    public ResponseEntity<ResultResponse> createPost(
+            @RequestPart(name = "postCreateRequest") PostCreateRequest request,
+            @RequestPart(name = "file", required = false) MultipartFile file) throws IOException{
+        final PostCreateResponse response = postService.create(request, file);
 
         return ResponseEntity.ok(ResultResponse.of(CREATE_POST_SUCCESS, response));
     }

--- a/src/main/java/wegrus/clubwebsite/controller/PostController.java
+++ b/src/main/java/wegrus/clubwebsite/controller/PostController.java
@@ -41,7 +41,7 @@ public class PostController {
     @PostMapping(value = "/posts")
     public ResponseEntity<ResultResponse> createPost(
             @RequestPart(name = "postCreateRequest") PostCreateRequest request,
-            @RequestPart(name = "file", required = false) MultipartFile file) throws IOException{
+            @RequestPart(name = "file", required = false) MultipartFile file) throws IOException {
         final PostCreateResponse response = postService.create(request, file);
 
         return ResponseEntity.ok(ResultResponse.of(CREATE_POST_SUCCESS, response));

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostCreateResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostCreateResponse.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PostCreateResponse {
     private Long postId;
+    private String fileUrl;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostCreateResponse.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostCreateResponse.java
@@ -7,5 +7,4 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PostCreateResponse {
     private Long postId;
-    private String fileUrl;
 }

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostDto.java
@@ -8,6 +8,7 @@ import wegrus.clubwebsite.vo.Image;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -28,11 +29,12 @@ public class PostDto {
     private Integer postReplies;
     private Integer postView;
     private Integer postBookmarks;
+    private List<String> postFileUrls;
     private boolean userPostLiked;
     private boolean userPostBookmarked;
     private boolean secretFlag;
 
-    public PostDto(Post post, boolean userPostLiked, boolean userPostBookmarked) {
+    public PostDto(Post post, boolean userPostLiked, boolean userPostBookmarked, List<String> postFileUrls) {
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
         this.memberName = post.getMember().getStudentId().substring(2, 4) + post.getMember().getName();
@@ -48,6 +50,7 @@ public class PostDto {
         this.postReplies = post.getPostReplyNum();
         this.postView = post.getViews().size();
         this.postBookmarks = post.getBookmarks().size();
+        this.postFileUrls = postFileUrls;
         this.userPostLiked = userPostLiked;
         this.userPostBookmarked = userPostBookmarked;
         this.secretFlag = post.isSecretFlag();

--- a/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
+++ b/src/main/java/wegrus/clubwebsite/dto/post/PostUnknownDto.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import wegrus.clubwebsite.entity.post.Post;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -23,11 +24,12 @@ public class PostUnknownDto {
     private Integer postReplies;
     private Integer postView;
     private Integer postBookmarks;
+    private List<String> postFileUrls;
     private boolean userPostLiked;
     private boolean userPostBookmarked;
     private boolean secretFlag;
 
-    public PostUnknownDto(Post post, boolean userPostLiked, boolean userPostBookmarked) {
+    public PostUnknownDto(Post post, boolean userPostLiked, boolean userPostBookmarked, List<String> postFileUrls) {
         this.postId = post.getId();
         this.memberId = post.getMember().getId();
         this.memberName = "알 수 없음";
@@ -42,6 +44,7 @@ public class PostUnknownDto {
         this.postReplies = post.getPostReplyNum();
         this.postView = post.getViews().size();
         this.postBookmarks = post.getBookmarks().size();
+        this.postFileUrls = postFileUrls;
         this.userPostLiked = userPostLiked;
         this.userPostBookmarked = userPostBookmarked;
         this.secretFlag = post.isSecretFlag();

--- a/src/main/java/wegrus/clubwebsite/entity/post/Post.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/Post.java
@@ -51,6 +51,9 @@ public class Post {
     @OneToMany(mappedBy = "post")
     private List<PostImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post")
+    private List<PostFile> files = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(name = "post_type")
     private PostType type;

--- a/src/main/java/wegrus/clubwebsite/entity/post/PostFile.java
+++ b/src/main/java/wegrus/clubwebsite/entity/post/PostFile.java
@@ -1,0 +1,39 @@
+package wegrus.clubwebsite.entity.post;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wegrus.clubwebsite.vo.File;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "post_files")
+public class PostFile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_file_id", insertable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "url", column = @Column(name = "post_file_url")),
+            @AttributeOverride(name = "type", column = @Column(name = "post_file_type")),
+            @AttributeOverride(name = "name", column = @Column(name = "post_file_name")),
+            @AttributeOverride(name = "uuid", column = @Column(name = "post_file_uuid"))
+    })
+    private File file;
+
+    @Builder
+    public PostFile(Post post, File file) {
+        this.post = post;
+        this.file = file;
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
@@ -1,0 +1,7 @@
+package wegrus.clubwebsite.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wegrus.clubwebsite.entity.post.PostFile;
+
+public interface PostFileRepository extends JpaRepository<PostFile, Long> {
+}

--- a/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
@@ -3,5 +3,8 @@ package wegrus.clubwebsite.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wegrus.clubwebsite.entity.post.PostFile;
 
+import java.util.Optional;
+
 public interface PostFileRepository extends JpaRepository<PostFile, Long> {
+    Optional<PostFile> findByPostId(Long postId);
 }

--- a/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
+++ b/src/main/java/wegrus/clubwebsite/repository/PostFileRepository.java
@@ -1,10 +1,18 @@
 package wegrus.clubwebsite.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import wegrus.clubwebsite.entity.post.Post;
 import wegrus.clubwebsite.entity.post.PostFile;
 
 import java.util.Optional;
 
 public interface PostFileRepository extends JpaRepository<PostFile, Long> {
     Optional<PostFile> findByPostId(Long postId);
+
+    @Modifying
+    @Query("DELETE FROM PostFile p WHERE p.post = :post")
+    void deletePostFilesByPost(@Param("post") Post post);
 }

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -167,6 +167,13 @@ public class PostService {
         }
         postImageRepository.deletePostImagesByPost(post);
 
+        // 파일 삭제
+        List<PostFile> postFiles = post.getFiles();
+        for (PostFile postFile : postFiles) {
+            amazonS3Util.deleteFile(postFile.getFile(), "files/posts/" + postId);
+        }
+        postFileRepository.deletePostFilesByPost(post);
+
         postRepository.delete(post);
     }
 

--- a/src/main/java/wegrus/clubwebsite/service/PostService.java
+++ b/src/main/java/wegrus/clubwebsite/service/PostService.java
@@ -78,8 +78,6 @@ public class PostService {
 
 
         // 파일 업로드
-        String fileUrl = "";
-
         if (multipartFile != null) {
             final String dirName = "files/posts/" + postId;
 
@@ -91,8 +89,6 @@ public class PostService {
                     .file(file)
                     .post(post)
                     .build();
-
-            fileUrl = file.getUrl();
 
             postFileRepository.save(postFile);
         }
@@ -116,7 +112,7 @@ public class PostService {
             }
         }
 
-        return new PostCreateResponse(postId, fileUrl);
+        return new PostCreateResponse(postId);
     }
 
     @Transactional

--- a/src/main/java/wegrus/clubwebsite/util/AmazonS3Util.java
+++ b/src/main/java/wegrus/clubwebsite/util/AmazonS3Util.java
@@ -58,6 +58,11 @@ public class AmazonS3Util {
         deleteS3(filename);
     }
 
+    public void deleteFile(wegrus.clubwebsite.vo.File file, String dirName) {
+        final String filename = dirName + "/" + file.getUuid() + "_" + file.getName() + "." + file.getType();
+        deleteS3(filename);
+    }
+
     public String uploadFile(File uploadFile, String fileName) {
         final String uploadImageUrl = putS3(uploadFile, fileName);
         removeNewFile(uploadFile);

--- a/src/main/java/wegrus/clubwebsite/util/AmazonS3Util.java
+++ b/src/main/java/wegrus/clubwebsite/util/AmazonS3Util.java
@@ -23,12 +23,23 @@ public class AmazonS3Util {
 
     private final AmazonS3Client amazonS3Client;
     private final ImageUtil imageUtil;
+    private final FileUtil fileUtil;
 
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;
 
     public void createDirectory(String dirName) {
         amazonS3Client.putObject(bucket, dirName + "/", new ByteArrayInputStream(new byte[0]), new ObjectMetadata());
+    }
+
+    public wegrus.clubwebsite.vo.File uploadFile(MultipartFile multipartFile, String dirName) throws IOException {
+        final wegrus.clubwebsite.vo.File file = fileUtil.convertMultipartFile(multipartFile);
+        final String fileName = dirName + "/" + file.getUuid() + "_" + file.getName() + "." + file.getType();
+
+        final File uploadFile = convert(multipartFile).orElseThrow(MultipartfileConvertException::new);
+        final String url = uploadFile(uploadFile, fileName);
+        file.setUrl(url);
+        return file;
     }
 
     public Image uploadImage(MultipartFile multipartFile, String dirName) throws IOException {

--- a/src/main/java/wegrus/clubwebsite/util/FileUtil.java
+++ b/src/main/java/wegrus/clubwebsite/util/FileUtil.java
@@ -1,0 +1,23 @@
+package wegrus.clubwebsite.util;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import wegrus.clubwebsite.vo.File;
+
+import java.util.UUID;
+
+@Component
+public class FileUtil {
+    public File convertMultipartFile(MultipartFile multipartFile) {
+        String originalName = multipartFile.getOriginalFilename();
+        String name = FilenameUtils.getBaseName(originalName);
+        String type = FilenameUtils.getExtension(originalName);
+
+        return File.builder()
+                .type(type)
+                .name(name)
+                .uuid(UUID.randomUUID().toString())
+                .build();
+    }
+}

--- a/src/main/java/wegrus/clubwebsite/vo/File.java
+++ b/src/main/java/wegrus/clubwebsite/vo/File.java
@@ -1,0 +1,42 @@
+package wegrus.clubwebsite.vo;
+
+import lombok.*;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class File {
+
+    private String url;
+
+    private String type;
+
+    private String name;
+
+    private String uuid;
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUuid());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+
+        File file = (File) obj;
+        return Objects.equals(getUuid(), file.getUuid());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,7 @@ spring:
     group:
       local: local, aws, oauth
       prod: prod, aws, oauth
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB


### PR DESCRIPTION
## 🎨PR Category
> PR 종류를 선택해주세요.

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## 📌Linked Issues
> `#이슈번호` 형태로 추가해주세요.

- Resolve #61 

## ✏PR Summary
> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

### PostFile entity 추가
- 현재는 게시물 1개당 하나의 파일만 받아 Post 엔티티 값을 수정해도 됨
- 추후 설계 변경을 대비해서 entity로 추가
  - ex) 게시물 1개당 여러 파일만 받도록 변경될 경우

### 게시물 작성 api 파일 업로드 기능 추가
- File과 Dto를 같이 받기 위해서 RequestBody -> RequestPart로 PostCreateRequest 받도록 변경
- swagger에서 테스트 불가능, postman에서 content/type을 application/json으로 변경, 테스트 완료
![postman_test1](https://user-images.githubusercontent.com/59475880/154133434-6eaf673c-c825-4602-927b-6234a502ee6a.png)
- 위 사진은 테스트를 위해서 게시물 작성 api 성공시 첨부파일 url을 반환, 현재는 postId만 반환하는 상태

### 게시물 조회 api 파일 다운로드 링크 추가
- 첨부파일 다운받을 수 있는 링크 리스트에 감싸서 반환

### 게시물 삭제 api 변경
- 게시물 삭제 시 해당 게시물의 첨부파일 서버에서 삭제
- PostFile에서 해당 데이터 삭제


## 💬Comment
> 추가로 논의할 내용이 있다면 적어주세요.

- 게시물 등록 api 시 기존에 RequestBody로 받던 json값을 RequestPart으로 변경함에 따라, 기존의 방식으로 요청하면 에러가 발생한다.
  - 따라서 프런트에서 해당 api 호출 시 content-type: 'application/json'으로 변경하는 것이 필수

## 📑References
> 참고한 사이트가 있다면 공유해주세요.

- [File과 Dto 동시에 받기](https://emoney96.tistory.com/258)
- [Rest Api Post와 Content-Type의 관계](https://m.blog.naver.com/PostView.nhn?blogId=writer0713&logNo=221853596497&proxyReferer=https:%2F%2Fblog.naver.com%2Fwriter0713%2F221853596497)

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
